### PR TITLE
added java-install-script to dockerfile

### DIFF
--- a/dockerscripts/Dockerfile
+++ b/dockerscripts/Dockerfile
@@ -24,6 +24,7 @@ RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-s
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
 RUN  chmod a+x ./install-script
 RUN ./install-script a 
+RUN ./java-install-script
 WORKDIR /opt/
 # Checkout latest Kinesis Video Streams Producer SDK (Java)
 RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java.git


### PR DESCRIPTION
*Issue # 35*

*Description of changes:*
needed to run java-install-script as part of dockerfile for demo to work according to instructions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
