### PR TITLE
ubuntu docker image updated to latest as 17 is no longer maintained

### DIFF
--- a/dockerscripts/Dockerfile
+++ b/dockerscripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 RUN apt-get update
 RUN apt-get install -y git && \
     apt-get install -y vim  && \
@@ -22,9 +22,7 @@ RUN git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-s
 #
 # Build the Producer SDK (CPP)
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/kinesis-video-native-build/
-RUN  chmod a+x ./install-script
 RUN  chmod a+x ./java-install-script
-RUN ./install-script -a
 RUN ./java-install-script
 WORKDIR /opt/
 # Checkout latest Kinesis Video Streams Producer SDK (Java)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/issues/77

*Description of changes:*
Ubuntu docker image updated to latest as 17 is no longer maintained

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
