### PR TITLE
Add CachedInfoMultiAuthServiceCallbacks to Java producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.key
 *.gpg
 cm-file
+.DS_Store

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
@@ -1,0 +1,169 @@
+package com.amazonaws.kinesisvideo.demoapp;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
+import com.amazonaws.kinesisvideo.common.logging.Log;
+import com.amazonaws.kinesisvideo.common.logging.LogLevel;
+import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
+import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.kinesisvideo.demoapp.auth.AuthHelper;
+import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsProviderImpl;
+import com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory;
+import com.amazonaws.kinesisvideo.java.logging.SysOutLogChannel;
+import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSource;
+import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSourceConfiguration;
+import com.amazonaws.kinesisvideo.java.service.CachedInfoMultiAuthServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient;
+import com.amazonaws.kinesisvideo.storage.DefaultStorageCallbacks;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.APIName;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointResult;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Demo Java Producer with Cached Stream Information to lower start latency.
+ */
+public final class DemoAppCachedInfo {
+    // Use a different stream name when testing audio/video sample
+    private static final String STREAM_NAME = "my-stream-cached";
+    private static final int FPS_25 = 25;
+    private static final int RETENTION_ONE_HOUR = 1;
+    private static final String IMAGE_DIR = "src/main/resources/data/h264/";
+    private static final String FRAME_DIR = "src/main/resources/data/audio-video-frames";
+    private static final int STREAM_DURATION_IN_MS = 10000;
+    // CHECKSTYLE:SUPPRESS:LineLength
+    // This is a reference pipline to extract frames. Need to get key frame configured properly so the output can be
+    // decoded. h264 files can be decoded using gstreamer plugin
+    // gst-launch-1.0 rtspsrc location="YourRtspUri" short-header=TRUE protocols=tcp ! rtph264depay ! decodebin ! videorate ! videoscale ! vtenc_h264_hw allow-frame-reordering=FALSE max-keyframe-interval=25 bitrate=1024 realtime=TRUE ! video/x-h264,stream-format=avc,alignment=au,profile=baseline,width=640,height=480,framerate=1/25 ! multifilesink location=./frame-%03d.h264 index=1
+    private static final String IMAGE_FILENAME_FORMAT = "frame-%03d.h264";
+    private static final int START_FILE_INDEX = 1;
+    private static final int END_FILE_INDEX = 375;
+    private static final int NUMBER_OF_THREADS_IN_POOL = 10;
+
+    private DemoAppCachedInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static void main(final String[] args) {
+        try {
+            final ScheduledExecutorService executor = Executors.newScheduledThreadPool(NUMBER_OF_THREADS_IN_POOL,
+                    new ThreadFactoryBuilder().setNameFormat("KVS-JavaClientExecutor-%d").build());
+            final AWSCredentialsProvider awsCredentialsProvider = AuthHelper.getSystemPropertiesCredentialsProvider();
+            final KinesisVideoClientConfiguration configuration = KinesisVideoClientConfiguration.builder()
+                    .withRegion(Regions.US_WEST_2.getName())
+                    .withCredentialsProvider(new JavaCredentialsProviderImpl(awsCredentialsProvider))
+                    .withLogChannel(new SysOutLogChannel())
+                    .withStorageCallbacks(new DefaultStorageCallbacks())
+                    .build();
+            final Log log = new Log(configuration.getLogChannel(), LogLevel.DEBUG, "KinesisVideo");
+
+            // Create CachedInfoServiceCallback
+            final CachedInfoMultiAuthServiceCallbacksImpl serviceCallbacks =
+                    new CachedInfoMultiAuthServiceCallbacksImpl(log, executor,
+                            configuration, new JavaKinesisVideoServiceClient(log));
+            // create Kinesis Video high level client
+            final KinesisVideoClient kinesisVideoClient = KinesisVideoJavaClientFactory
+                    .createKinesisVideoClient(log, configuration, executor, null, serviceCallbacks);
+
+
+            final String streamName1 = STREAM_NAME + "-account-1";
+            final String streamName2 = STREAM_NAME + "-account-2";
+            // Cached stream info can be added to callback provider any time, different credentials callback could be
+            // used for different streams
+            addCachedStreamInfoWithCredentialsProvider(serviceCallbacks, streamName1, awsCredentialsProvider,
+                    configuration.getRegion());
+            addCachedStreamInfoWithCredentialsProvider(serviceCallbacks, streamName2, awsCredentialsProvider,
+                    configuration.getRegion());
+
+            // create a media source. this class produces the data and pushes it into
+            // Kinesis Video Producer lower level components
+            final MediaSource mediaSource1 = createImageFileMediaSource(streamName1);
+
+            // register media source with Kinesis Video Client
+            // NOTE: CachedInfoMultiAuthServiceCallbacksImpl can be used with registerMediaSourceAsync only now
+            kinesisVideoClient.registerMediaSourceAsync(mediaSource1);
+
+            // start streaming
+            mediaSource1.start();
+
+            final MediaSource mediaSource2 = createImageFileMediaSource(streamName2);
+
+            // register media source with Kinesis Video Client
+            // NOTE: CachedInfoMultiAuthServiceCallbacksImpl can be used with registerMediaSourceAsync only now
+            kinesisVideoClient.registerMediaSourceAsync(mediaSource2);
+
+            // start streaming
+            mediaSource2.start();
+
+            // Run for 10 seconds then stop
+            try {
+                Thread.sleep(STREAM_DURATION_IN_MS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            // unregister stream from client and free client
+            serviceCallbacks.removeStreamFromCache(streamName1);
+            kinesisVideoClient.unregisterMediaSource(mediaSource1);
+            serviceCallbacks.removeStreamFromCache(streamName2);
+            kinesisVideoClient.unregisterMediaSource(mediaSource2);
+            kinesisVideoClient.free();
+            executor.shutdown();
+        } catch (final KinesisVideoException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create a MediaSource based on local sample H.264 frames.
+     *
+     * @return a MediaSource backed by local H264 frame files
+     */
+    private static MediaSource createImageFileMediaSource(String streamName) {
+        final ImageFileMediaSourceConfiguration configuration =
+                new ImageFileMediaSourceConfiguration.Builder()
+                        .fps(FPS_25)
+                        .dir(IMAGE_DIR)
+                        .filenameFormat(IMAGE_FILENAME_FORMAT)
+                        .startFileIndex(START_FILE_INDEX)
+                        .endFileIndex(END_FILE_INDEX)
+                        //.contentType("video/hevc") // for h265
+                        .build();
+        final ImageFileMediaSource mediaSource = new ImageFileMediaSource(streamName);
+        mediaSource.configure(configuration);
+
+        return mediaSource;
+    }
+
+
+
+    private static void addCachedStreamInfoWithCredentialsProvider(CachedInfoMultiAuthServiceCallbacksImpl serviceCallbacks,
+                                                                   String streamName,
+                                                                   AWSCredentialsProvider credentialsProvider,
+                                                                   String region) {
+        // Set up credentials provider for the stream name
+        serviceCallbacks.addCredentialsProviderToCache(streamName, credentialsProvider);
+
+        // Set up stream info for the stream name
+        AmazonKinesisVideo kvsClient = AmazonKinesisVideoClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(credentialsProvider)
+                .build();
+        DescribeStreamResult streamInfo = kvsClient.describeStream(new DescribeStreamRequest().withStreamName(streamName));
+        serviceCallbacks.addStreamInfoToCache(streamName, streamInfo);
+
+        // Set up endpoint for the stream name
+        GetDataEndpointResult dataEndpoint =
+                kvsClient.getDataEndpoint(new GetDataEndpointRequest().withAPIName(APIName.PUT_MEDIA).withStreamName(streamName));
+        serviceCallbacks.addStreamingEndpointToCache(streamName, dataEndpoint.getDataEndpoint());
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClient.java
@@ -53,6 +53,16 @@ public interface KinesisVideoClient {
     void registerMediaSource(final MediaSource mediaSource) throws KinesisVideoException;
 
     /**
+     * Register a media source ASYNC. The media source will be binding to kinesis video producer stream
+     * via CreateStream and send out data from media source.
+     * Async call to create the stream and bind to media source.
+     *
+     * @param mediaSource media source binding to kinesis video producer stream
+     * @throws KinesisVideoException if unable to register media source.
+     */
+    void registerMediaSourceAsync(final MediaSource mediaSource) throws KinesisVideoException;
+
+    /**
      * Un-Register a media source. The media source will stop binding to kinesis video producer stream
      * and it cannot send data via producer stream afterwards until register again.
      * Sync call and could be block for 15 seconds if error happens when stopping stream.

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/client/AbstractKinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/client/AbstractKinesisVideoClient.java
@@ -143,6 +143,11 @@ public abstract class AbstractKinesisVideoClient implements KinesisVideoClient {
         mMediaSources.add(mediaSource);
     }
 
+    @Override
+    public void registerMediaSourceAsync(@Nonnull final MediaSource mediaSource) throws KinesisVideoException {
+        mMediaSources.add(mediaSource);
+    }
+
     /**
      * Un-Register a media source. The media source will stop binding to kinesis video producer stream
      * and it cannot send data via producer stream afterwards until register again.

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/client/NativeKinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/client/NativeKinesisVideoClient.java
@@ -136,6 +136,21 @@ public class NativeKinesisVideoClient extends AbstractKinesisVideoClient {
     }
 
     @Override
+    public void registerMediaSourceAsync(@Nonnull final MediaSource mediaSource) throws KinesisVideoException {
+        Preconditions.checkNotNull(mediaSource);
+        StreamCallbacks streamCallbacks = mediaSource.getStreamCallbacks();
+        if (streamCallbacks == null) {
+            streamCallbacks = mStreamCallbacks;
+        }
+
+        final KinesisVideoProducerStream producerStream = kinesisVideoProducer.createStream(mediaSource.getStreamInfo(), streamCallbacks);
+        mediaSource.initialize(new ProducerStreamSink(producerStream));
+        mServiceCallbacks.addStream(producerStream);
+        mMediaSourceToStreamMap.put(mediaSource, producerStream);
+        super.registerMediaSource(mediaSource);
+    }
+
+    @Override
     public void unregisterMediaSource(@Nonnull final MediaSource mediaSource) throws KinesisVideoException {
         Preconditions.checkNotNull(mediaSource);
         mediaSource.stop();

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
@@ -748,7 +748,8 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         synchronized (mCallbackSyncObject) {
             synchronized (mSyncObject) {
                 if (!mKinesisVideoHandleMap.containsKey(streamHandle)) {
-                    throw new ProducerException("Invalid stream handle.", STATUS_INVALID_OPERATION);
+                    mLog.info("Stream Ready for non-existing stream handle " + streamHandle);
+                    return;
                 }
 
                 final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
@@ -28,19 +28,19 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.ACCESS_DENIED;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_ACCESS_DENIED;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_BAD_REQUEST;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_NOT_FOUND;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_OK;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_RESOURCE_IN_USE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RESOURCE_IN_USE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RESOURCE_NOT_FOUND;
+
 /**
  * Implementation of {@link ServiceCallbacks}
  */
 public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
-    private static final int HTTP_OK = 200;
-    private static final int HTTP_BAD_REQUEST = 400;
-    private static final int HTTP_NOT_FOUND = 404;
-    private static final int HTTP_RESOURCE_IN_USE = 10003;
-    private static final int HTTP_ACCESS_DENIED = 403;
-    private static final String RESOURCE_NOT_FOUND = "ResourceNotFoundException";
-    private static final String RESOURCE_IN_USE = "ResourceInUseException";
-    private static final String ACCESS_DENIED = "AccessDeniedException";
-
     private class CompletionCallback implements Consumer<Exception> {
         private final KinesisVideoProducerStream stream;
         private final long uploadHandle;
@@ -103,27 +103,27 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
     /**
      * Task executor to schedule long-running tasks in an async way.
      */
-    private final ScheduledExecutorService executor;
+    protected final ScheduledExecutorService executor;
 
     /**
      * Kinesis video service client to make the service calls with.
      */
-    private final KinesisVideoServiceClient kinesisVideoServiceClient;
+    protected final KinesisVideoServiceClient kinesisVideoServiceClient;
 
     /**
      * Log object to use
      */
-    private final Log log;
+    protected final Log log;
 
     /**
      * Store the configuration
      */
-    private final KinesisVideoClientConfiguration configuration;
+    protected final KinesisVideoClientConfiguration configuration;
 
     /**
      * Implementation of the {@link KinesisVideoProducer} object.
      */
-    private KinesisVideoProducer kinesisVideoProducer = null;
+    protected KinesisVideoProducer kinesisVideoProducer = null;
 
     /**
      * The list of streams for which the callbacks can be applied.
@@ -590,7 +590,7 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                 System.currentTimeMillis() * Time.NANOS_IN_A_MILLISECOND);
     }
 
-    private long getUploadHandle() {
+    private synchronized long getUploadHandle() {
         return uploadHandle++;
     }
 
@@ -624,7 +624,8 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
     }
 
     @Nullable
-    private static KinesisVideoCredentialsProvider getCredentialsProvider(@Nullable final byte[] authData, @Nonnull final Log log) {
+    protected static KinesisVideoCredentialsProvider getCredentialsProvider(@Nullable final byte[] authData,
+                                                                    @Nonnull final Log log) {
         if (null == authData) {
             log.warn("NULL credentials have been returned by the credentials provider.");
             return null;
@@ -661,7 +662,7 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
      * @param e {@link Throwable} which was thrown by the service client
      * @return status code corresponding to the exception
      */
-    private static int getStatusCodeFromException(@Nullable final Throwable e) {
+    protected static int getStatusCodeFromException(@Nullable final Throwable e) {
         // TODO: Implement this properly
         if (e == null) {
             return HTTP_OK;

--- a/src/main/java/com/amazonaws/kinesisvideo/java/client/JavaKinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/client/JavaKinesisVideoClient.java
@@ -4,6 +4,7 @@ import com.amazonaws.kinesisvideo.auth.DefaultAuthCallbacks;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
 import com.amazonaws.kinesisvideo.common.logging.Log;
+import com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks;
 import com.amazonaws.kinesisvideo.producer.StreamCallbacks;
 import com.amazonaws.kinesisvideo.internal.producer.client.KinesisVideoServiceClient;
 import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
@@ -43,12 +44,25 @@ public final class JavaKinesisVideoClient extends NativeKinesisVideoClient {
             @Nonnull final KinesisVideoServiceClient serviceClient,
             @Nonnull final ScheduledExecutorService executor,
             @Nonnull final StreamCallbacks streamCallbacks) {
+        this(log,
+                configuration,
+                new DefaultServiceCallbacksImpl(log, executor, configuration, serviceClient),
+                executor,
+                streamCallbacks);
+    }
+
+    public JavaKinesisVideoClient(
+            @Nonnull final Log log,
+            @Nonnull final KinesisVideoClientConfiguration configuration,
+            @Nonnull final ServiceCallbacks serviceCallbacks,
+            @Nonnull final ScheduledExecutorService executor,
+            @Nonnull final StreamCallbacks streamCallbacks) {
         super(log,
                 new DefaultAuthCallbacks(configuration.getCredentialsProvider(),
                         executor,
                         log),
                 configuration.getStorageCallbacks(),
-                new DefaultServiceCallbacksImpl(log, executor, configuration, serviceClient),
+                serviceCallbacks,
                 streamCallbacks);
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
@@ -137,6 +137,6 @@ public class ImageFrameSource {
 
 
     private void stopFrameGenerator() {
-
+        executor.shutdown();
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/service/CachedInfoMultiAuthServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/service/CachedInfoMultiAuthServiceCallbacksImpl.java
@@ -1,0 +1,322 @@
+package com.amazonaws.kinesisvideo.java.service;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentials;
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
+import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.kinesisvideo.common.logging.Log;
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducer;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.internal.producer.client.KinesisVideoServiceClient;
+import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsProviderImpl;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StreamDescription;
+import com.amazonaws.kinesisvideo.producer.StreamStatus;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.kinesisvideo.producer.Time;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.amazonaws.kinesisvideo.common.preconditions.Preconditions.checkNotNull;
+import static com.amazonaws.kinesisvideo.producer.Time.HUNDREDS_OF_NANOS_IN_AN_HOUR;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_BAD_REQUEST;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_OK;
+
+public class CachedInfoMultiAuthServiceCallbacksImpl extends DefaultServiceCallbacksImpl {
+    public CachedInfoMultiAuthServiceCallbacksImpl(@Nonnull Log log, @Nonnull ScheduledExecutorService executor,
+                                                   @Nonnull KinesisVideoClientConfiguration configuration,
+                                                   @Nonnull KinesisVideoServiceClient kinesisVideoServiceClient) {
+        super(log, executor, configuration, kinesisVideoServiceClient);
+    }
+
+    /**
+     * StreamArn -> Credentials Provider
+     */
+    private Map<String, KinesisVideoCredentialsProvider> credentialsProviderMap = new HashMap<>();
+
+    /**
+     * StreamArn -> StreamInfo
+     */
+    private Map<String, DescribeStreamResult> streamInfoMap = new HashMap<>();
+
+    /**
+     * StreamArn -> Data Endpoint
+     */
+    private Map<String, String> endpointMap = new HashMap<>();
+
+    /**
+     * StreamArn -> Tags for the stream
+     */
+    private Map<String, Tag[]> tagInfoMap = new HashMap<>();
+
+
+    /**
+     * Initializes the object
+     *
+     * @param kinesisVideoProducer Reference to {@link KinesisVideoProducer} for the eventing.
+     */
+    @Override
+    public void initialize(@Nonnull final KinesisVideoProducer kinesisVideoProducer) {
+        Preconditions.checkState(!isInitialized(), "Service callback object has already been initialized");
+        this.kinesisVideoProducer = Preconditions.checkNotNull(kinesisVideoProducer);
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return kinesisVideoProducer != null;
+    }
+
+    @Override
+    public void createStream(@Nonnull final String deviceName,
+                             @Nonnull final String streamName,
+                             @Nonnull final String contentType,
+                             @Nullable final String kmsKeyId,
+                             final long retentionPeriod,
+                             final long callAfter,
+                             final long timeout,
+                             @Nullable final byte[] authData,
+                             final int authType,
+                             final long customData)
+            throws ProducerException {
+        throw new ProducerException(
+                "Stream need to be pre-existing if using CachedInfoMultiAuthServiceCallbacksImpl.", 0);
+    }
+
+    @Override
+    public void describeStream(
+            @Nonnull final String streamName,
+            final long callAfter,
+            final long timeout,
+            @Nullable final byte[] authData,
+            final int authType,
+            final long streamHandle,
+            final KinesisVideoProducerStream stream) throws ProducerException {
+
+        Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
+        final DescribeStreamResult streamInfo = streamInfoMap.get(streamName);
+        if (streamInfo == null) {
+            throw new ProducerException("Stream Description is not given for stream " + streamName, 0);
+        }
+        final StreamDescription streamDescription = toStreamDescription(streamInfo);
+        try {
+            kinesisVideoProducer.describeStreamResult(stream, streamHandle, streamDescription, HTTP_OK);
+        } catch (final ProducerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void getStreamingEndpoint(
+            @Nonnull final String streamName,
+            @Nonnull final String apiName,
+            final long callAfter,
+            final long timeout,
+            @Nullable final byte[] authData,
+            final int authType,
+            final long streamHandle,
+            final KinesisVideoProducerStream stream) throws ProducerException {
+
+        Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
+
+        String endpoint = endpointMap.get(streamName);
+
+        if (endpoint == null) {
+            throw new ProducerException("Streaming Endpoint is not given for stream " + streamName, 0);
+        }
+
+        kinesisVideoProducer.getStreamingEndpointResult(stream, streamHandle, endpoint, HTTP_OK);
+    }
+
+    @Override
+    public void getStreamingToken(
+            @Nonnull final String streamName,
+            final long callAfter,
+            final long timeout,
+            @Nullable final byte[] authData,
+            final int authType,
+            final long streamHandle,
+            final KinesisVideoProducerStream stream) throws ProducerException {
+
+        Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
+
+        final KinesisVideoCredentialsProvider kvsCredentialsProvider = credentialsProviderMap.get(streamName);
+
+        // Stores the serialized credentials as a streaming token
+        byte[] serializedCredentials = null;
+        long expiration = 0;
+
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try {
+            final KinesisVideoCredentials credentials = kvsCredentialsProvider.getUpdatedCredentials();
+
+            // Serialize the credentials
+            expiration = credentials.getExpiration().getTime() * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+            // Serialize the credentials as streaming token
+            final ObjectOutput outputStream = new ObjectOutputStream(byteArrayOutputStream);
+            outputStream.writeObject(credentials);
+            outputStream.flush();
+            serializedCredentials = byteArrayOutputStream.toByteArray();
+            outputStream.close();
+        } catch (final IOException e) {
+            log.exception(e);
+        } catch (final KinesisVideoException e) {
+            log.exception(e);
+        } finally {
+            try {
+                byteArrayOutputStream.close();
+            } catch (final IOException ex) {
+                // Do nothing
+            }
+        }
+
+        final int statusCode = HTTP_OK;
+
+        try {
+            kinesisVideoProducer.getStreamingTokenResult(
+                    stream,
+                    streamHandle,
+                    serializedCredentials,
+                    expiration,
+                    statusCode);
+        } catch (final ProducerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void tagResource(@Nonnull final String resourceArn,
+                            @Nullable final Tag[] tagsUnused,
+                            final long callAfter,
+                            final long timeout,
+                            @Nullable final byte[] authData,
+                            final int authType,
+                            final long streamHandle,
+                            final KinesisVideoProducerStream stream) throws ProducerException {
+
+        Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
+        final long delay = calculateRelativeServiceCallAfter(callAfter);
+        // arn:aws:kinesisvideo:us-west-2:xxxxxxxxxxx:stream/streamName/xxxxxxxxxxxxx
+        // stream object is not ready if tagStream is in createStreamSync() process, so stream.getStreamName() cannot
+        // be used
+        final String[] arns = resourceArn.split("/");
+        Tag[] tagsOfStream = null;
+        if (arns.length > 2) {
+            tagsOfStream = tagInfoMap.get(arns[1]);
+        }
+        if (tagsOfStream == null || tagsOfStream.length == 0) {
+            try {
+                kinesisVideoProducer.tagResourceResult(stream, streamHandle, HTTP_OK);
+            } catch (final ProducerException e) {
+                throw new RuntimeException(e);
+            }
+            return;
+        }
+        final Tag[] tags = tagsOfStream;
+
+        final Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                final KinesisVideoCredentialsProvider credentialsProvider = getCredentialsProvider(authData, log);
+                final long timeoutInMillis = timeout / Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+                int statusCode = HTTP_OK;
+
+                Map<String, String> tagsMap = null;
+                if (null != tags) {
+                    // Convert the tags to map
+                    tagsMap = new HashMap<String, String>(tags.length);
+
+                    for (final Tag tag : tags) {
+                        tagsMap.put(tag.getName(), tag.getValue());
+                    }
+                }
+                try {
+                    kinesisVideoServiceClient.tagStream(resourceArn,
+                            tagsMap,
+                            timeoutInMillis,
+                            credentialsProvider);
+                } catch (final KinesisVideoException e) {
+                    log.error("Kinesis Video service client returned an error " + e.getMessage()
+                            + ". Reporting to Kinesis Video PIC.");
+                    statusCode = getStatusCodeFromException(e);
+                }
+
+                if (statusCode != HTTP_OK) {
+                    // TODO: more URI validation
+                    statusCode = HTTP_BAD_REQUEST;
+                }
+
+                try {
+                    kinesisVideoProducer.tagResourceResult(stream, streamHandle, statusCode);
+                } catch (final ProducerException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        executor.schedule(task, delay, TimeUnit.NANOSECONDS);
+    }
+
+    public void addStreamInfoToCache(String streamName, DescribeStreamResult streamInfo) {
+        Preconditions.checkArgument(!streamInfoMap.containsKey(streamName));
+        streamInfoMap.put(streamName, streamInfo);
+    }
+
+    public void addTagInfoToCache(String streamName, Tag[] tags) {
+        Preconditions.checkArgument(!tagInfoMap.containsKey(streamName));
+        tagInfoMap.put(streamName, tags);
+    }
+
+    public void addStreamingEndpointToCache(String streamName, String endpoint) {
+        Preconditions.checkArgument(!endpointMap.containsKey(streamName));
+        endpointMap.put(streamName, endpoint);
+    }
+
+    public void addCredentialsProviderToCache(String streamName, AWSCredentialsProvider credentialsProvider) {
+        Preconditions.checkArgument(!credentialsProviderMap.containsKey(streamName));
+        final KinesisVideoCredentialsProvider kvsCredentialsProvider =
+                new JavaCredentialsProviderImpl(credentialsProvider);
+        credentialsProviderMap.put(streamName, kvsCredentialsProvider);
+    }
+
+    public void removeStreamFromCache(String streamName) {
+        credentialsProviderMap.remove(streamName);
+        streamInfoMap.remove(streamName);
+        endpointMap.remove(streamName);
+        tagInfoMap.remove(streamName);
+    }
+
+    private long calculateRelativeServiceCallAfter(final long absoluteCallAfter) {
+        return Math.max(0, absoluteCallAfter * Time.NANOS_IN_A_TIME_UNIT
+                - System.currentTimeMillis() * Time.NANOS_IN_A_MILLISECOND);
+    }
+
+    private static StreamDescription toStreamDescription(final @NonNull DescribeStreamResult result) {
+        checkNotNull(result);
+        return new StreamDescription(
+                StreamDescription.STREAM_DESCRIPTION_CURRENT_VERSION,
+                result.getStreamInfo().getDeviceName(),
+                result.getStreamInfo().getStreamName(),
+                result.getStreamInfo().getMediaType(),
+                result.getStreamInfo().getVersion(),
+                result.getStreamInfo().getStreamARN(),
+                StreamStatus.valueOf(result.getStreamInfo().getStatus()),
+                result.getStreamInfo().getCreationTime().getTime(),
+                result.getStreamInfo().getDataRetentionInHours() * HUNDREDS_OF_NANOS_IN_AN_HOUR,
+                result.getStreamInfo().getKmsKeyId());
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/util/StreamInfoConstants.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/util/StreamInfoConstants.java
@@ -7,6 +7,15 @@ import static com.amazonaws.kinesisvideo.producer.Time.HUNDREDS_OF_NANOS_IN_A_SE
  * All the time unit used in this class is 100 ns (minimum unit used in producer SDK)
  */
 public final class StreamInfoConstants {
+    public static final int HTTP_OK = 200;
+    public static final int HTTP_BAD_REQUEST = 400;
+    public static final int HTTP_NOT_FOUND = 404;
+    public static final int HTTP_RESOURCE_IN_USE = 10003;
+    public static final int HTTP_ACCESS_DENIED = 403;
+    public static final String RESOURCE_NOT_FOUND = "ResourceNotFoundException";
+    public static final String RESOURCE_IN_USE = "ResourceInUseException";
+    public static final String ACCESS_DENIED = "AccessDeniedException";
+
     public static final boolean NOT_ADAPTIVE = false;
     public static final boolean KEYFRAME_FRAGMENTATION = true;
     public static final boolean SDK_GENERATES_TIMECODES = false;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This callback allows user to use different credentials providers for
 different streams in one client with existing stream information so
no extra API call will be made except PutMedia, this can make start up
latency minimum with cached stream information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
