### PR TITLE
Provision to use app supplied stream timeout value

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ mvn clean compile assembly:single
 
 Start the demo app
 ```
-$ java -classpath target/amazon-kinesis-video-streams-producer-sdk-java-1.10.0-jar-with-dependencies.jar -Daws.accessKeyId=<ACCESS_KEY> -Daws.secretKey=<SECRET_KEY> -Dkvs-stream=<KINESIS_VIDEO_STREAM_NAME> -Djava.library.path=<NativeLibraryPath> com.amazonaws.kinesisvideo.demoapp.DemoAppMain
+$ java -classpath target/amazon-kinesis-video-streams-producer-sdk-java-1.11.0-jar-with-dependencies.jar -Daws.accessKeyId=<ACCESS_KEY> -Daws.secretKey=<SECRET_KEY> -Dkvs-stream=<KINESIS_VIDEO_STREAM_NAME> -Djava.library.path=<NativeLibraryPath> com.amazonaws.kinesisvideo.demoapp.DemoAppMain
 
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-kinesis-video-streams-producer-sdk-java</artifactId>
     <name>Amazon Kinesis Video Streams Producer SDK Java</name>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
     <description>The Amazon Kinesis Video Streams Producer SDK for Java enables Java developers to ingest data into
         Amazon Kinesis Video.
     </description>

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
@@ -126,6 +126,11 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
     private final KinesisVideoMetrics mKinesisVideoMetrics;
 
     /**
+     * Used to store device info
+     */
+    private DeviceInfo mDeviceInfo;
+
+    /**
      * Public constructor.
      * @param authCallbacks Authentication callbacks
      * @param storageCallbacks Storage callbacks
@@ -218,6 +223,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         Preconditions.checkNotNull(deviceInfo);
         Preconditions.checkState(!isInitialized());
 
+        mDeviceInfo = deviceInfo;
         synchronized (mSyncObject) {
             if (!mLibraryInitialized) {
                 initializeLibrary(nativeLibraryPath);
@@ -321,7 +327,8 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
                     streamInfo,
                     streamHandle,
                     mLog,
-                    streamCallbacks);
+                    streamCallbacks, 
+                    mDeviceInfo);
 
             // Insert into the maps
             mKinesisVideoHandleMap.put(streamHandle, kinesisVideoProducerStream);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current implementation of `awaitStopped()` uses the default of 15 second timeout, thus, not honoring application provided stop stream timeout value. The PR changes this by using default if no value is supplied and the supplied value otherwise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
