### PR TITLE
Bug fix for `skipEmptyLines` method in `ChunkDecoder`

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/encoding/ChunkDecoder.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/encoding/ChunkDecoder.java
@@ -221,7 +221,7 @@ public final class ChunkDecoder {
         do {
             line = reader.readLine();
         }
-        while (line != null && line.isEmpty());
+        while (line == null || line.isEmpty());
 
         return line;
     }


### PR DESCRIPTION
Instead of reading until the end of line and returning the first non null line

There seems to be a bug at this `skipEmptyLines` method in the `decodeAckInResponseBody` method in `ChunkDecoder`, it seems to be reading until the line is not empty and not null, instead of reading until the line is empty and null, and then finding the next line which is after null or empty line.

    private static String skipEmptyLines(final BufferedReader reader) throws Throwable {
        String line;
        do {
            line = reader.readLine();
        }
        while (line != null && line.isEmpty());
        return line;
    }

This while loop seems to be doing the reading till the line is not null and line is empty, that means until the line is empty to be precise, as line is not `null`, if line is `null` or empty `  `, this returns, which means, the returned value is always either null or not empty, but does not guarantee that line is not null.

This will cause the point of caller at `ChunkDecoder` line #183

            line = skipEmptyLines(reader);

            // Parse chunk data
            LOG.debug("Chunk size: " + line);
            do {
                chunkSize = Integer.parseInt(line.trim(), HEX_RADIX); //  point 1

At point 1, the code will fail with NPE, when calling `line.trim()`, if line is `null`, please review this, as if `skipEmptyLines`, it was noted by SONAR as well by S2259 [Null pointers should not be dereferenced], which made me analyze and request for this pull request. It is perfectly normal for `BufferedReader.readLine()` to return null, if the file line has no input at all, instead of just "".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
