### PR TITLE
Fix section of README describing NativeLibraryPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for *temporary* AWS credential.
 * `libKinesisVideoProducerJNI.dylib` for Mac OS
 * `KinesisVideoProducerJNI.dll` for Windows
 
-If you are using pre-built libraries, please specify the path of library. Take pre-build library for Mac as example, you can specify `src/resources/lib/mac` as <NativeLibraryPath>.
+If you are using pre-built libraries, please specify the path of library. Take pre-build library for Mac as example, you can specify `src/main/resources/lib/mac` as \<NativeLibraryPath\>.
 
 Demo app will start running and putting sample video frames in a loop into Kinesis Video Streams. You can change your stream settings in `DemoAppMain.java` before you run the app.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes 2 small things I noticed:
1. `NativeLibraryPath` in one part of the README was not rendering because it was surrounded by angle brackets:
Before:
![Screen Shot 2022-09-23 at 10 49 54 AM](https://user-images.githubusercontent.com/6569270/191998503-8b065a4a-1ab6-4bef-b988-78bd862664d9.png)
After:
![Screen Shot 2022-09-23 at 11 35 03 AM](https://user-images.githubusercontent.com/6569270/191998653-01a8983c-e6b0-4413-922d-1d1a07c3c480.png)

2. Fixes the path to the mac native library. When I tried using the one specified in the README, I got an error like:
```
java.lang.UnsatisfiedLinkError: no KinesisVideoProducerJNI in java.library.path: src/resources/lib/mac
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
