### PR TITLE
Add note about demo app expecting stream in us-west-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ for *temporary* AWS credential.
 
 If you are using pre-built libraries, please specify the path of library. Take pre-build library for Mac as example, you can specify `src/resources/lib/mac` as <NativeLibraryPath>.
 
+**Note**: Make sure the stream name that you specify exists in the region the app runs in. This demo app is set to run in us-west-2 by default.
+
 Demo app will start running and putting sample video frames in a loop into Kinesis Video Streams. You can change your stream settings in `DemoAppMain.java` before you run the app.
 
 ##### Run the demo application from command line


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I initially tried to run the demo script, I was using a kvs-stream in the us-east-1 environment and I was 404 errors from Kinesis that took a few minutes to debug before I realized the demo script was expecting a stream in us-west-2. This just adds a note to the readme to hopefully save others a few minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
