### PR TITLE
Use System.getProperty for stream name in PutMediaDemo

### DIFF
--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/PutMediaDemo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/PutMediaDemo.java
@@ -45,7 +45,7 @@ public final class PutMediaDemo {
     private static final String PUT_MEDIA_API = "/putMedia";
 
     /* the name of the stream */
-    private static final String STREAM_NAME = "my-stream";
+    private static final String STREAM_NAME = System.getProperty("kvs-stream");
 
     /* sample MKV file */
     private static final String MKV_FILE_PATH = "src/main/resources/data/mkv/clusters.mkv";


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This updates the PutMediaDemo so that it uses the `STREAM_NAME` value that is set by the system property rather than being hardcoded to `"my-stream"`. The documentation in the README indicates that this is how the `PutMediaDemo` should operate so this is just making the actual code consistent with what is already in the docs.

This tripped me up for a while before I noticed that the STREAM_NAME was actually hardcoded in this demo.

The relevant docs:
![Screen Shot 2022-09-26 at 1 56 19 PM](https://user-images.githubusercontent.com/6569270/192361766-f71deaca-e685-4ba1-b95e-9f4613723ead.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
