### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     strategy:
+      # Unit and integration tests are not thread safe as they all use the same stream names.
+      max-parallel: 1
       matrix:
         os: [ macos-14, ubuntu-22.04, windows-2022 ]
         java: [ 8, 11, 17, 21 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Producer SDK Java CI with Maven
 
 on:
   push:
-    branches: 
+    branches:
       - develop
       - master
   pull_request:
@@ -12,31 +12,37 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ macos-14, ubuntu-22.04, windows-2022 ]
+        java: [ 8, 11, 17, 21 ]
+
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write
       contents: read
-    strategy:
-      matrix:
-        os: [ macos-10.15, ubuntu-18.04, windows-2019]
-        java: [ 8, 11, 16 ]
+
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: maven
+
       - name: Build with Maven
         run: mvn clean compile assembly:single
+
       - name: Run tests
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then


### PR DESCRIPTION
*Issue #, if available:*
* N/A

*Description of changes:*
* Update the GItHub runner images. GitHub no longer supports macos-10.15 or ubuntu-18.04, according to https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.
* **Limit to 1 job running at a time** -- The stream names in the integration tests are all the same. Do not want the possibility of test runs interfering with each other.
* Update `actions/checkout` to latest.
* Update `aws-actions/configure-aws-credentials` to latest. There was an issue with the previous version reporting "Error: Input required and not supplied: aws-region" even though it was supplied: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/actions/runs/11166351312/job/31250374063
* Remove Java 16 from the version test list. Add 17 and 21 to the version test list, as those are more commonly used than 16. https://newrelic.com/resources/report/2024-state-of-the-java-ecosystem

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
