### PR TITLE
Dual-stack endpoint support, IP filter, unit test enhancements, CI enhancements with JNI generation

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - os: macos-13
+      name: macos-x86_64
+    - os: macos-latest
+      name: macos-aarch64
+    - os: ubuntu-22.04
+      name: ubuntu-22.04
+    - os: windows-2022
+      name: windows-2022
+  java:
+    - 11
+  sample:
+    - DemoAppMain
+    - DemoAppCachedInfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,118 @@ on:
       - master
 
 jobs:
-  build:
-    strategy:
-      # Unit and integration tests are not thread safe as they all use the same stream names.
-      max-parallel: 1
-      matrix:
-        os: [ macos-14, ubuntu-22.04, windows-2022 ]
-        java: [ 8, 11, 17, 21 ]
+  load-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      build_jni_matrix: ${{ steps.set-matrix.outputs.build_jni_matrix }}
+      unit_test_matrix: ${{ steps.set-matrix.outputs.unit_test_matrix }}
+      sample_matrix: ${{ steps.set-matrix.outputs.sample_matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    runs-on: ${{ matrix.os }}
+      - name: Load matrix from YAML
+        id: set-matrix
+        run: |
+          MATRIX=$(yq eval '.matrix | explode(.)' .github/matrix.yaml -o=json)
+
+          BUILD_JNI_MATRIX=$(echo "$MATRIX" | jq -c '{platform: .platform}')
+          UNIT_TEST_MATRIX=$(echo "$MATRIX" | jq -c '{platform: .platform, java: .java}')
+          SAMPLE_MATRIX=$(echo "$MATRIX" | jq -c '.')
+
+          echo "build_jni_matrix=$BUILD_JNI_MATRIX" >> $GITHUB_OUTPUT
+          echo "unit_test_matrix=$UNIT_TEST_MATRIX" >> $GITHUB_OUTPUT
+          echo "sample_matrix=$SAMPLE_MATRIX" >> $GITHUB_OUTPUT
+
+  build-jni:
+    needs: load-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.load-matrix.outputs.build_jni_matrix) }}
+      fail-fast: false
+
+    runs-on: ${{ matrix.platform.os }}
+
+    env:
+      BRANCH_NAME: develop
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'adopt'
+          cache: maven
+
+      - name: Build JNI (Mac and Linux)
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        run: |
+          git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git --single-branch -b ${{ env.BRANCH_NAME }}
+          cd amazon-kinesis-video-streams-producer-sdk-cpp
+          mkdir build
+          cd build
+          cmake .. -DBUILD_JNI_ONLY=ON
+          make -j
+
+      - name: Build JNI (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: cmd
+        run: |
+          @echo on
+
+          :: Create a shorter directory to avoid long path issues
+          mkdir D:\work || exit /b 1
+          git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git D:\work\producer --single-branch -b ${{ env.BRANCH_NAME }} || exit /b 1
+
+          :: Ensure cloning succeeded
+          if not exist "D:\work\producer" (
+              echo "Error: Clone failed, directory does not exist."
+              exit /b 1
+          )
+
+          cd D:\work\producer || exit /b 1
+
+          :: Create build directory
+          mkdir build || exit /b 1
+          cd build || exit /b 1
+
+          :: Run CMake with the correct path
+          cmake .. -DBUILD_JNI_ONLY=ON -G "Visual Studio 17 2022" || exit /b 1
+          cmake --build . --config Release --verbose || exit /b 1
+
+          :: Move the compiled library to the expected location
+          :: Note: Using Visual Studio generator, the output file gets put in Release\KinesisVideoProducerJNI.dll
+          :: rather than in the build folder directly
+          cd "%GITHUB_WORKSPACE%" || exit /b 1
+          mkdir amazon-kinesis-video-streams-producer-sdk-cpp || exit /b 1
+          mkdir amazon-kinesis-video-streams-producer-sdk-cpp\build || exit /b 1
+          move D:\work\producer\build\Release\KinesisVideoProducerJNI.dll amazon-kinesis-video-streams-producer-sdk-cpp\build || exit /b 1
+
+      - name: Upload JNI Library
+        uses: actions/upload-artifact@v4
+        with:
+          name: jni-library-${{ matrix.platform.name }}
+          path: |
+            amazon-kinesis-video-streams-producer-sdk-cpp/build/libKinesisVideoProducerJNI.so
+            amazon-kinesis-video-streams-producer-sdk-cpp/build/libKinesisVideoProducerJNI.dylib
+            amazon-kinesis-video-streams-producer-sdk-cpp/build/KinesisVideoProducerJNI.dll
+          retention-days: 1
+
+  run-unit-tests:
+    needs:
+      - load-matrix
+      - build-jni
+    strategy:
+      matrix: ${{ fromJson(needs.load-matrix.outputs.unit_test_matrix) }}
+      fail-fast: false
+
+    env:
+      TEST_STREAMS_PREFIX: producer-java-${{ matrix.platform.os }}-java-${{ matrix.java }}_
+      JNI_FOLDER: ${{ github.workspace }}/jni
+
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       id-token: write
       contents: read
@@ -28,33 +131,171 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: maven
 
+      - name: Download JNI Library
+        uses: actions/download-artifact@v4
+        with:
+          name: jni-library-${{ matrix.platform.name }}
+          path: jni/
+
       - name: Build with Maven
         run: mvn clean compile assembly:single
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Run tests
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            mvn clean test -DargLine="-Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} -Djava.library.path=src/main/resources/lib/ubuntu/ -Dlog4j.configurationFile=log4j2.xml"
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            mvn clean test -DargLine="-Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} -Djava.library.path=src/main/resources/lib/windows/ -Dlog4j.configurationFile=log4j2.xml"
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            mvn clean test -DargLine="-Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} -Djava.library.path=src/main/resources/lib/mac/ -Dlog4j.configurationFile=log4j2.xml"
-          else
-            echo "$RUNNER_OS not supported"
+          mvn clean test -DargLine="-Daws.accessKeyId=${AWS_ACCESS_KEY_ID} -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} -Daws.sessionToken=${AWS_SESSION_TOKEN} -Djava.library.path=${JNI_FOLDER} -Dlog4j.configurationFile=log4j2.xml"
+        shell: bash
+
+  run-samples:
+    needs:
+      - load-matrix
+      - build-jni
+    strategy:
+      matrix: ${{ fromJson(needs.load-matrix.outputs.sample_matrix) }}
+      fail-fast: false
+
+    env:
+      STREAM_NAME: producer-java-${{ matrix.platform.os }}-java-${{ matrix.java }}_${{ matrix.sample }}
+      JNI_FOLDER: ${{ github.workspace }}/jni
+
+    runs-on: ${{ matrix.platform.os }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+          cache: maven
+
+      - name: Download JNI Library
+        uses: actions/download-artifact@v4
+        with:
+          name: jni-library-${{ matrix.platform.name }}
+          path: jni/
+
+      - name: Install dependencies (MacOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew install coreutils # For `gtimeout`
+
+      - name: Build with Maven
+        run: mvn clean compile assembly:single
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Create the stream (DemoAppCachedInfo)
+        # This sample needs a pre-created stream: `${NAME}`
+        if: ${{ matrix.sample == 'DemoAppMain' }}
+        working-directory: scripts
+        run: |
+          ./prepareStream.sh "$STREAM_NAME"
+
+        shell: bash
+
+      - name: Create the stream (DemoAppCachedInfo)
+        # This sample needs 2 pre-created streams: `${NAME}-account-1` and `${NAME}-account-2`
+        if: ${{ matrix.sample == 'DemoAppCachedInfo' }}
+        working-directory: scripts
+        run: |
+          ./prepareStream.sh "$STREAM_NAME-account-1"
+          ./prepareStream.sh "$STREAM_NAME-account-2"
+
+        shell: bash
+
+      - name: Run the sample
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        run: |
+          set +e
+
+          JAR_FILE=$(find target -name '*jar-with-dependencies.jar' | head -n 1)
+
+          if [ -z "$JAR_FILE" ]; then
+            echo "Error: JAR file not found!"
             exit 1
           fi
+
+          echo "Using JAR file: $JAR_FILE"
+
+          # Use gtimeout on macOS and timeout on Linux
+          if [ "${{ runner.os }}" == "macOS" ]; then
+            TIMEOUT_CMD="gtimeout"
+          else
+            TIMEOUT_CMD="timeout"
+          fi
+
+          $TIMEOUT_CMD 30s java -classpath "$JAR_FILE" \
+            -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} \
+            -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} \
+            -Daws.sessionToken=${AWS_SESSION_TOKEN} \
+            -Djava.library.path=${JNI_FOLDER} \
+            -Dkvs-stream=$STREAM_NAME \
+            -Dlog4j.configurationFile=log4j2.xml \
+            com.amazonaws.kinesisvideo.demoapp.${{ matrix.sample }}
+
+          EXIT_CODE=$?
+
+          set -e
+
+          # Check if the process was forcefully killed
+          if [ $EXIT_CODE -eq 124 ]; then
+            echo "Error: Sample application exceeded 30 seconds and was forcefully terminated."
+            exit 1
+          fi
+
+          # Preserve original exit code
+          echo "Process exited with code: $EXIT_CODE"
+          exit $EXIT_CODE
+
         shell: bash
+
+      - name: Run the sample (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: cmd
+        run: |
+          for /f "delims=" %%F in ('dir /b /s target\*jar-with-dependencies.jar') do set JAR_FILE=%%F
+
+          if not defined JAR_FILE (
+            echo Error: JAR file not found!
+            exit /b 1
+          )
+
+          echo Using JAR file: %JAR_FILE%
+
+          timeout /t 30 /nobreak && exit /b 124
+
+          java -classpath "%JAR_FILE%" ^
+            -Daws.accessKeyId=%AWS_ACCESS_KEY_ID% ^
+            -Daws.secretKey=%AWS_SECRET_ACCESS_KEY% ^
+            -Daws.sessionToken=%AWS_SESSION_TOKEN% ^
+            -Djava.library.path=%JNI_FOLDER% ^
+            -Dkvs-stream=%STREAM_NAME% ^
+            -Dlog4j.configurationFile=log4j2.xml ^
+            com.amazonaws.kinesisvideo.demoapp.${{ matrix.sample }}
+
+          set EXIT_CODE=%ERRORLEVEL%
+
+          echo Process exited with code: %EXIT_CODE%
+          exit /b %EXIT_CODE%

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 cm-file
 .DS_Store
 target
+logs
+hs_err_pid*.log
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
-## Amazon Kinesis Video Streams Producer SDK Java
+<h1 align="center">
+  Amazon Kinesis Video Streams Producer SDK Java
+  <br>
+</h1>
 
-## License
+<h4 align="center"> Amazon Kinesis Video Streams | Secure Video Ingestion for Analysis &amp; Storage </h4>
 
-This library is licensed under the Apache License, 2.0. 
+<p align="center">
+  <a href="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/actions/workflows/ci.yml"> <img src="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/actions/workflows/ci.yml/badge.svg"> </a>
+</p>
+
+<p align="center">
+  <a href="#building-from-source">Build</a> •
+  <a href="#run-examples">Run</a> •
+  <a href="#troubleshooting">Troubleshooting</a> •
+  <a href="#resources">Resources</a> •
+  <a href="#development">Development</a> •
+  <a href="#release-notes">Release Notes</a> •
+  <a href="#license">License</a>
+</p>
 
 ## Introduction
 
@@ -19,60 +34,99 @@ The Amazon Kinesis Video Streams Producer SDK Java makes it easy to build an on-
 
 ### Prerequisites
 
-* You can find available pre-built KinesisVideoProducerJNI library in [src/main/resources/lib/](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/tree/master/src/main/resources/lib) for Mac (x64), Ubuntu (x64) and Raspian (x86) and Windows 10. If pre-built libraries did not work for you, ["KinesisVideoProducerJNI"](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp) native library needs to be built first before running the Java demo application. Please follow the steps  in the section **Build the native library (KinesisVideoProducerJNI) to run Java Demo App** in Producer SDK CPP [readme](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp).
+* You can find available pre-built KinesisVideoProducerJNI library in [src/main/resources/lib/](./src/main/resources/lib) for Mac (x64), Ubuntu (x64) and Raspian (x86) and Windows 10. If pre-built libraries did not work for you, ["KinesisVideoProducerJNI"](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp) native library needs to be built first before running the Java demo application. Please follow the steps  in the section **Build the native library (KinesisVideoProducerJNI) to run Java Demo App** in Producer SDK CPP [readme](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp).
 
 ### Building from Source
 
-Import the Maven project to your IDE, it will find dependency packages from Maven and build.
+#### In an IDE
 
-### Examples
+Import the Maven project ([`pom.xml`](./pom.xml)) to your IDE, it will find dependency packages from Maven and build.
+
+#### Using command-line
+
+Make sure you have Java and Maven installed on your system.
+
+```sh
+git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java.git
+cd amazon-kinesis-video-streams-producer-sdk-java
+mvn clean compile assembly:single
+```
+
+### Run Examples
+
+#### Preparing a stream
+
+You can create a stream using the AWS management console using the instructions [here](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/gs-createstream.html).
+
+If you have AWS CLI installed and configured, you can also run the [prepareStream.sh](./scripts/prepareStream.sh) script to verify the stream exists and has data retention enabled.
+If either or both conditions fail, it will fix them for you. To use it:
+
+```shell
+./scripts/prepareStream.sh <YourKinesisVideoStreamName>
+```
 
 #### Launching Demoapp sample application
 
-Run `DemoAppMain.java` in `./src/main/demo` with JVM arguments set to
-```
--Daws.accessKeyId=<YourAwsAccessKey> -Daws.secretKey=<YourAwsSecretKey> -Dkvs-stream=<YourKinesisVideoStreamName> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml
-```
-for **non-temporary** AWS credential.
+Demo app will start running and putting sample video frames in a loop into Kinesis Video Streams.
+You can change your stream settings in [`DemoAppMain.java`](./src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java) before you run the app.
 
-```
--Daws.accessKeyId=<YourAwsAccessKey> -Daws.secretKey=<YourAwsSecretKey> -Daws.sessionToken=<YourAwsSessionToken> -Dkvs-stream=<YourKinesisVideoStreamName> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml
-```
-for *temporary* AWS credential.
+To run [`DemoAppMain.java`](./src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java) in `./src/main/demo` with JVM arguments:
 
-**Note**: NativeLibraryPath must contain your ["KinesisVideoProducerJNI"](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp#build-the-native-library-kinesisvideoproducerjni-to-run-java-demo-app) library. File name depends on your Operating System:
-* `libKinesisVideoProducerJNI.so` for Linux
-* `libKinesisVideoProducerJNI.dylib` for Mac OS
-* `KinesisVideoProducerJNI.dll` for Windows
+1. Credentials: `aws.accessKeyId`, `aws.secretKey`, `aws.sessionToken` (optional)
+2. Stream name: `kvs-stream`
+3. JNI library path: `java.library.path`
+4. Log4j configuration file: `log4j.configurationFile`
 
-If you are using pre-built libraries, please specify the path of library. Take pre-build library for Mac as example, you can specify `src/resources/lib/mac` as <NativeLibraryPath>.
-
-Demo app will start running and putting sample video frames in a loop into Kinesis Video Streams. You can change your stream settings in `DemoAppMain.java` before you run the app.
-
-##### Run the demo application from command line
-
-If you want to run the `DemoAppMain`, follow the [steps](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/issues/14) below. See [Prerequisites](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java#prerequisites) to find available native library needed to run `DemoAppMain`.
-
-Change the current working directory to
-
-```
-$ cd /<YOUR_FOLDER_PATH_WHERE_SDK_IS_DOWNLOADED>/amazon-kinesis-video-streams-producer-sdk-java/
+```sh
+java -classpath target/*jar-with-dependencies.jar \
+  -Daws.accessKeyId=<YourAwsAccessKey> \
+  -Daws.secretKey=<YourAwsSecretKey> \
+  -Dkvs-stream=<YourKinesisVideoStreamName> \
+  -Djava.library.path=<NativeLibraryPath ex. src/main/lib/mac> \
+  -Dlog4j.configurationFile=log4j2.xml \
+  com.amazonaws.kinesisvideo.demoapp.DemoAppMain
 ```
 
-Compile and assemble Java SDK, Java Demoapp and the Maven dependencies
-```
-$ mvn clean compile assembly:single
+> [!NOTE]
+> On Windows command prompt, the newline separator is `^` instead of `\`.
+
+> [!NOTE]
+> NativeLibraryPath must contain path to the folder containing your ["KinesisVideoProducerJNI"](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp) library (not to the file itself). File name depends on your operating system:
+> * `libKinesisVideoProducerJNI.so` for Linux
+> * `libKinesisVideoProducerJNI.dylib` for Mac OS
+> * `KinesisVideoProducerJNI.dll` for Windows
+
+> [!TIP]
+> Pre-built JNI libraries for some systems can be found in `src/resources/lib`.
+
+> [!NOTE]
+> If your system isn't part of the pre-built JNI libraries, you will need to build the JNI yourself. You can find instructions [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/wiki/Building-and-Using-JNI).
+
+##### Changing the log level
+
+Locate the log4j configuration file `log4j2.xml`, and change the level (currently `WARN`) to something else like `INFO` or `DEBUG`. For a full list of levels, see the [log4j documentation](https://logging.apache.org/log4j/2.x/manual/customloglevels.html).
+
+```xml
+<Loggers>
+    <Root level="WARN">
+        <AppenderRef ref="ConsoleAppender"/>
+        <AppenderRef ref="RollingFile"/>
+    </Root>
+</Loggers>
 ```
 
-Start the demo app
-```
-$ java -classpath target/amazon-kinesis-video-streams-producer-sdk-java-1.12.1-jar-with-dependencies.jar -Daws.accessKeyId=<ACCESS_KEY> -Daws.secretKey=<SECRET_KEY> -Dkvs-stream=<KINESIS_VIDEO_STREAM_NAME> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml com.amazonaws.kinesisvideo.demoapp.DemoAppMain
-
-```
 ##### Run API and functionality tests
+```sh
+mvn clean test -DargLine="\
+  -Daws.accessKeyId=<YourAwsAccessKey> \
+  -Daws.secretKey=<YourAwsSecretKey> \
+  -Daws.sessionToken=<YourAwsSessionToken> \
+  -Djava.library.path=<NativeLibraryPath> \
+  -Dlog4j.configurationFile=log4j2.xml"
 ```
-$ mvn clean test -DargLine="-Daws.accessKeyId=<YourAwsAccessKey> -Daws.secretKey=<YourAwsSecretKey> -Daws.sessionToken=<YourAwsSessionToken> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml"
-```
+
+> [!NOTE]
+> The tests require pre-provisioned streams and require data retention enabled. If either or both conditions are not met, the tests will attempt to fix them before starting.
 
 ##### Run the demo application from Docker
 
@@ -104,29 +158,77 @@ For additional examples on using Kinesis Video Streams Java SDK and  Kinesis Vid
 
 ##### [Kinesis Video Streams Android](https://github.com/awslabs/aws-sdk-android-samples/tree/master/AmazonKinesisVideoDemoApp)
 
-#### Troubleshooting
+### Troubleshooting
 
-If you notice error in loading the native library (JNI), then check the output of `ldd` or `otool`
+#### Unsatisfied link error - no KinesisVideoProducerJNI in java.library.path
 
-```
-$ ldd libKinesisVideoProducerJNI.so
-```
-or in MacOS
-```
-$ otool -L libKinesisVideoProducerJNI.dylib
+Provide the path to the *folder* containing the KinesisVideoProducerJNI library (not the file itself) as part of `java.library.path` JVM argument.
+
+#### Other Unsatisfied link error
+
+If you notice error in loading the native library (JNI), it may be due to CPU architecture mismatch.
+Check the error in the logging output.
+
+<details>
+<summary>Sample output</summary>
+
+```log
+20:49:47.747 [main] ERROR com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory - Unsatisfied link error.
+java.lang.UnsatisfiedLinkError: /Users/me/Desktop/libKinesisVideoProducerJNI.dylib: dlopen(/Users/me/Desktop/libKinesisVideoProducerJNI.dylib, 0x0001): tried: '/Users/me/Desktop/libKinesisVideoProducerJNI.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/me/Desktop/libKinesisVideoProducerJNI.dylib' (no such file), '/Users/me/Desktop/libKinesisVideoProducerJNI.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
+	at jdk.internal.loader.NativeLibraries.load(Native Method) ~[?:?]
+	at jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:331) ~[?:?]
+	at jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:197) ~[?:?]
+	at jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139) ~[?:?]
+	at jdk.internal.loader.NativeLibraries.findFromPaths(NativeLibraries.java:259) ~[?:?]
+	at jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:251) ~[?:?]
+	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:2451) ~[?:?]
+	at java.lang.Runtime.loadLibrary0(Runtime.java:916) ~[?:?]
+	at java.lang.System.loadLibrary(System.java:2063) ~[?:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeLibraryLoader.loadNativeLibraryIndirect(NativeLibraryLoader.java:76) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeLibraryLoader.loadNativeLibrary(NativeLibraryLoader.java:44) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.initializeLibrary(NativeKinesisVideoProducerJni.java:1175) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.create(NativeKinesisVideoProducerJni.java:228) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.createSync(NativeKinesisVideoProducerJni.java:246) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.createSync(NativeKinesisVideoProducerJni.java:211) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.initializeNewKinesisVideoProducer(NativeKinesisVideoClient.java:239) [classes/:?]
+	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.initialize(NativeKinesisVideoClient.java:119) [classes/:?]
+	at com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory.createKinesisVideoClient(KinesisVideoJavaClientFactory.java:154) [classes/:?]
+	at com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory.createKinesisVideoClient(KinesisVideoJavaClientFactory.java:127) [classes/:?]
+	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:65) [classes/:?]
+Exception in thread "main" java.lang.RuntimeException: com.amazonaws.kinesisvideo.producer.ProducerException: Failed loading native library StatusCode: 0xd
+	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:93)
+Caused by: com.amazonaws.kinesisvideo.producer.ProducerException: Failed loading native library StatusCode: 0xd
 ```
 
-This will provide details on missing libraries during linking; If the output shows missing shared libraries, then run the following commands to link:
+</details>
 
-Run the following from the build directory in CPP producer SDK:
+If using the pre-built JNI libraries located in `src/main/resources/lib`, make sure you are using the one that matches your CPU architecture.
+
+If your architecture isn't provided as one of the pre-built libraries, you will need to build the JNI yourself.
+Building the JNI on your local system will make sure the correct architecture and bit-ness are used.
+See instructions [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/wiki/Building-and-Using-JNI).
+
+> [!NOTE]
+> If you run into issues building the JNI on your system, please raise an issue in repository where the JNI source code is located.
+
+#### Untrusted developer
+
+If you receive an error like this when trying to use the JNI:
+
+> `Apple could not verify "libKinesisVideoProducerJNI.dylib" is free of malware that may harm your Mac or compromise your privacy.`
+
+It is likely that you downloaded the file through the internet through a browser, email attachment, etc. (e.g. through the GitHub interface) instead of through `git clone`.
+
+> [!IMPORTANT]
+> Make sure the file came from a trusted source before proceeding.
+
+You can remove the quarantine flag like this:
+
+```shell
+sudo xattr -d -r com.apple.quarantine /path/to/libKinesisVideoProducerJNI.dylib
 ```
-cmake .. -DBUILD_JNI=TRUE 
-make
-```
 
-Then, provide the path to the libKinesisVideoProducerJNI.dylib library.
-
-This should resolve native library loading issues.
+If you prefer a GUI, you can go to `Preferences` > `Privacy & Security`, scroll down and choose "Allow Anyway".
 
 ## Development
 
@@ -262,3 +364,7 @@ The repository is using `develop` branch as the aggregation and all of the featu
 ### Release 1.0.0 (November 2017)
 
 * First release of the Amazon Kinesis Video Producer SDK Java.
+
+## License
+
+This library is licensed under the Apache License, 2.0. 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,20 @@ mvn clean compile assembly:single
 
 #### Preparing a stream
 
+##### AWS Management Console
+
 You can create a stream using the AWS management console using the instructions [here](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/gs-createstream.html).
 
-If you have AWS CLI installed and configured, you can also run the [prepareStream.sh](./scripts/prepareStream.sh) script to verify the stream exists and has data retention enabled.
-If either or both conditions fail, it will fix them for you. To use it:
+You can also edit the data retention in the AWS management console in the section under the media player.
+
+##### AWS CLI
+
+If you have AWS CLI and `jq` installed and configured, you can also run the [prepareStream.sh](./scripts/prepareStream.sh).
+
+This script will create a stream with the given name if the stream doesn't exist.
+
+> [!NOTE]
+> The script will increase the data retention of your stream to 2 hours if it's 0.
 
 ```shell
 ./scripts/prepareStream.sh <YourKinesisVideoStreamName>
@@ -119,6 +129,26 @@ Locate the log4j configuration file `log4j2.xml`, and change the level (currentl
 </Loggers>
 ```
 
+###### To change log level for a single class
+
+To change the log level for a single class, add a `<Logger>` element inside the `<Loggers>` section.
+
+```xml
+<Logger name="com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory" level="TRACE" additivity="false">
+    <AppenderRef ref="ConsoleAppender"/>
+    <AppenderRef ref="RollingFile"/>
+</Logger>
+```
+
+In the example above, we set the JNI logs to `TRACE`.
+
+Log levels to PIC equivalents:
+* `TRACE` = 1 -- `LOG_LEVEL_VERBOSE`
+* `DEBUG` = 2 -- `LOG_LEVEL_DEBUG`
+* `INFO` = 3 -- `LOG_LEVEL_INFO`
+* `WARN` = 4 -- `LOG_LEVEL_WARN`
+* `ERROR` = 5+ -- `LOG_LEVEL_ERROR`
+
 ##### Run API and functionality tests
 ```sh
 mvn clean test -DargLine="\
@@ -130,7 +160,7 @@ mvn clean test -DargLine="\
 ```
 
 > [!NOTE]
-> The tests require pre-provisioned streams and require data retention enabled. If either or both conditions are not met, the tests will attempt to fix them before starting.
+> The tests require pre-provisioned streams and require data retention enabled. If either or both conditions are not met, the tests will attempt to fix them before starting. Make sure this is OK in your account before running. Set the `TEST_STREAMS_PREFIX` environment variable to add a prefix to the streams used in the integration tests.
 
 ##### Generate code coverage report
 
@@ -171,6 +201,17 @@ For additional examples on using Kinesis Video Streams Java SDK and  Kinesis Vid
 ##### [Kinesis Video Streams Android](https://github.com/awslabs/aws-sdk-android-samples/tree/master/AmazonKinesisVideoDemoApp)
 
 ### Troubleshooting
+
+#### Class not found
+
+If you receive an error like this:
+
+```log
+Error: Could not find or load main class com.amazonaws.kinesisvideo.demoapp.DemoAppMain
+Caused by: java.lang.ClassNotFoundException: com.amazonaws.kinesisvideo.demoapp.DemoAppMain
+```
+
+Check the file path to the `.jar` is correct, and that the class name is correct.
 
 #### Unsatisfied link error - no KinesisVideoProducerJNI in java.library.path
 
@@ -223,24 +264,31 @@ See instructions [here](https://github.com/awslabs/amazon-kinesis-video-streams-
 > [!NOTE]
 > If you run into issues building the JNI on your system, please raise an issue in repository where the JNI source code is located.
 
-#### Untrusted developer
+#### macOS security warning
 
 If you receive an error like this when trying to use the JNI:
 
 > `Apple could not verify "libKinesisVideoProducerJNI.dylib" is free of malware that may harm your Mac or compromise your privacy.`
 
-It is likely that you downloaded the file through the internet through a browser, email attachment, etc. (e.g. through the GitHub interface) instead of through `git clone`.
+This usually means the file was downloaded from the internet using a browser, email attachment, or similar method
+(e.g., from the GitHub interface as a release artifact), rather than via `git clone` or directly from Maven Central.
 
 > [!IMPORTANT]
-> Make sure the file came from a trusted source before proceeding.
+> Only download files from trusted sources. Always verify the checksum.
 
-You can remove the quarantine flag like this:
+To remove the Gatekeeper quarantine flag, run:
 
 ```shell
 sudo xattr -d -r com.apple.quarantine /path/to/libKinesisVideoProducerJNI.dylib
 ```
 
+> [!TIP]
+> Use `man xattr` for more information, or see https://ss64.com/mac/xattr.html.
+
 If you prefer a GUI, you can go to `Preferences` > `Privacy & Security`, scroll down and choose "Allow Anyway".
+
+> [!NOTE]
+> For more information about Gatekeeper, see [Apple Documentation](https://support.apple.com/en-gb/102445).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
   <br>
 </h1>
 
-<h4 align="center"> Amazon Kinesis Video Streams | Secure Video Ingestion for Analysis &amp; Storage </h4>
-
 <p align="center">
   <a href="#building-from-source">Build</a> •
   <a href="#run-examples">Run</a> •
@@ -30,9 +28,19 @@ The Amazon Kinesis Video Streams Producer SDK Java makes it easy to build an on-
 
 ### Prerequisites
 
-* You can find available pre-built KinesisVideoProducerJNI library in [src/main/resources/lib/](./src/main/resources/lib) for Mac (x64), Ubuntu (x64) and Raspbian (x86) and Windows 10. If pre-built libraries did not work for you, KinesisVideoProducerJNI native library needs to be built first before running the Java demo application. Please follow the steps [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/wiki/Building-and-Using-JNI).
+* Java 11, 17, or 21
+* maven
+* JNI libraries
 
-### Building from Source
+#### Using pre-built JNI libraries
+
+* You can find available pre-built KinesisVideoProducerJNI library in [src/main/resources/lib/](./src/main/resources/lib) for Mac (x64), Ubuntu (x64) and Raspbian (x86) and Windows 10.
+
+#### Building JNI libraries
+
+* If pre-built libraries did not work for you, KinesisVideoProducerJNI native library needs to be built first before running the Java demo application. Please follow the steps [here](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/wiki/Building-and-Using-JNI).
+
+### Building the Java Producer SDK and Demo Applications from Source
 
 #### In an IDE
 
@@ -70,7 +78,7 @@ To run [`DemoAppMain.java`](./src/main/demo/com/amazonaws/kinesisvideo/demoapp/D
 
 1. Credentials: `aws.accessKeyId`, `aws.secretKey`, `aws.sessionToken` (optional)
 2. Stream name: `kvs-stream`
-3. JNI library path: `java.library.path`
+3. Path to JNI library directory: `java.library.path`
 4. Log4j configuration file: `log4j.configurationFile`
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -270,25 +270,7 @@ If you receive an error like this when trying to use the JNI:
 
 > `Apple could not verify "libKinesisVideoProducerJNI.dylib" is free of malware that may harm your Mac or compromise your privacy.`
 
-This usually means the file was downloaded from the internet using a browser, email attachment, or similar method
-(e.g., from the GitHub interface as a release artifact), rather than via `git clone` or directly from Maven Central.
-
-> [!IMPORTANT]
-> Only download files from trusted sources. Always verify the checksum.
-
-To remove the Gatekeeper quarantine flag, run:
-
-```shell
-sudo xattr -d -r com.apple.quarantine /path/to/libKinesisVideoProducerJNI.dylib
-```
-
-> [!TIP]
-> Use `man xattr` for more information, or see https://ss64.com/mac/xattr.html.
-
-If you prefer a GUI, you can go to `Preferences` > `Privacy & Security`, scroll down and choose "Allow Anyway".
-
-> [!NOTE]
-> For more information about Gatekeeper, see [Apple Documentation](https://support.apple.com/en-gb/102445).
+The above error should not appear if you cloned the repository using `git clone`. Download the artifacts using `git clone`.
 
 ## Development
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.11</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/com/amazonaws/kinesisvideo/demoapp/**</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/scripts/prepareStream.sh
+++ b/scripts/prepareStream.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# ==========================================
+# AWS Kinesis Video Stream Preparation Script
+# ==========================================
+# This script checks for the existence of an AWS Kinesis Video Stream.
+# If the stream does not exist, it creates it with a retention period.
+# If the stream exists but has no retention period set, it updates it.
+# The script also waits for the stream to become available after creation.
+#
+# Dependencies:
+# - AWS CLI: Used to interact with Kinesis Video Streams.
+# - jq: Used for processing JSON responses.
+#
+# Usage:
+#   ./prepare_stream.sh <stream-name>
+#
+# Example:
+#   ./prepare_stream.sh my-video-stream
+#
+# - Region -
+# To set the region, you can do:
+#   AWS_DEFAULT_REGION=us-west-2 ./prepare_stream.sh my-video-stream
+# Or you can set it in AWS CLI using `aws configure`
+#
+# Exit Codes:
+#   1 - Missing dependencies or incorrect usage.
+#   Non-zero exit codes from AWS CLI commands indicate failures.
+#
+# ==========================================
+
+set -euo pipefail
+
+# Constants
+MAX_RETRIES=5                # Maximum retries for checking stream creation
+DATA_RETENTION_HOURS=2       # Retention period in hours
+
+# Function to check if required dependencies are installed
+check_dependencies() {
+    if ! command -v aws &>/dev/null; then
+        echo "Error: AWS CLI is not installed. Please install it and configure credentials."
+        exit 1
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        echo "Error: jq is not installed. Please install jq to process JSON output."
+        exit 1
+    fi
+}
+
+# Function to check if a stream exists
+# Arguments:
+#   $1 - Stream name
+# Returns:
+#   0 if stream exists, 1 otherwise
+check_stream_exists() {
+    local stream_name="$1"
+
+    if aws kinesisvideo describe-stream --stream-name "$stream_name" --no-cli-pager >/dev/null 2>&1; then
+        return 0  # Stream exists
+    else
+        return 1  # Stream does not exist
+    fi
+}
+
+# Function to retrieve stream information as JSON
+# Arguments:
+#   $1 - Stream name
+# Outputs:
+#   JSON string containing stream details
+get_stream_info() {
+    local stream_name="$1"
+    aws kinesisvideo describe-stream --stream-name "$stream_name" --output json
+}
+
+# Function to update data retention if it is currently 0
+# Arguments:
+#   $1 - Stream name
+#   $2 - Stream information JSON
+update_retention_if_needed() {
+    local stream_name="$1"
+    local stream_info="$2"
+
+    local retention_hours
+    retention_hours=$(echo "$stream_info" | jq -r '.StreamInfo.DataRetentionInHours')
+
+    if [[ "$retention_hours" -eq 0 ]]; then
+        echo "Stream '$stream_name' has no retention set. Updating to ${DATA_RETENTION_HOURS} hours..."
+
+        # Extract the stream version required for updating retention
+        local version
+        version=$(echo "$stream_info" | jq -r '.StreamInfo.Version')
+
+        # Update the data retention period
+        aws kinesisvideo update-data-retention \
+            --stream-name "$stream_name" \
+            --current-version "$version" \
+            --operation INCREASE_DATA_RETENTION \
+            --data-retention-change-in-hours "$DATA_RETENTION_HOURS" \
+            --no-cli-pager
+
+        echo "Retention updated successfully."
+
+         # Fetch stream details again to verify retention settings were actually updated
+        sleep 1
+        local stream_info
+        stream_info=$(get_stream_info "$stream_name")
+        echo "Stream '$stream_name' exists: $(echo "$stream_info" | jq -r '.StreamInfo.StreamARN')"
+        update_retention_if_needed "$stream_name" "$stream_info"
+    else
+       echo "Stream '$stream_name' has data retention: ${DATA_RETENTION_HOURS} hours."
+    fi
+}
+
+# Function to create a new stream with the defined retention period
+# Arguments:
+#   $1 - Stream name
+create_stream() {
+    local stream_name="$1"
+    echo "Stream '$stream_name' does not exist. Creating..."
+    aws kinesisvideo create-stream --stream-name "$stream_name" --data-retention-in-hours "$DATA_RETENTION_HOURS" --no-cli-pager
+}
+
+# Function to wait for the stream to become available, using exponential backoff
+# Arguments:
+#   $1 - Stream name
+# Returns:
+#   0 if stream becomes available, non-zero exit code otherwise
+wait_for_stream_creation() {
+    local stream_name="$1"
+
+    echo "Waiting for stream '$stream_name' to be ready..."
+    for i in $(seq 0 $((MAX_RETRIES - 1))); do
+        sleep $((2 ** i))  # Exponential backoff (1s, 2s, 4s, 8s, 16s)
+
+        if check_stream_exists "$stream_name"; then
+            echo "Stream '$stream_name' is now available."
+            return 0
+        fi
+
+        echo "Stream is still being created... (attempt $((i + 1))/$MAX_RETRIES)"
+    done
+
+    echo "Stream creation timed out."
+    return 1
+}
+
+# Arguments:
+#   $1 - Stream name
+main() {
+    if [[ $# -ne 1 ]]; then
+        echo "Usage: $0 <stream-name>"
+        exit 1
+    fi
+
+    local stream_name="$1"
+
+    # Check dependencies before proceeding
+    check_dependencies
+
+    if check_stream_exists "$stream_name"; then
+        # Fetch stream details and check retention settings
+        local stream_info
+        stream_info=$(get_stream_info "$stream_name")
+        echo "Stream '$stream_name' exists: $(echo "$stream_info" | jq -r '.StreamInfo.StreamARN')"
+        update_retention_if_needed "$stream_name" "$stream_info"
+    else
+        # Create the stream and wait for it to be ready
+        create_stream "$stream_name"
+        wait_for_stream_creation "$stream_name"
+    fi
+}
+
+# Execute main function with arguments
+main "$@"

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
@@ -1,6 +1,7 @@
 package com.amazonaws.kinesisvideo.demoapp;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import org.apache.logging.log4j.LogManager;
@@ -24,7 +25,11 @@ import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
 import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
 import com.amazonaws.services.kinesisvideo.model.GetDataEndpointResult;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.logging.log4j.core.config.Configurator;
 
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -32,13 +37,26 @@ import java.util.concurrent.ScheduledExecutorService;
  * Demo Java Producer with Cached Stream Information to lower start latency.
  */
 public final class DemoAppCachedInfo {
+
+    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
     // Use a different stream name when testing audio/video sample
-    private static final String STREAM_NAME = "my-stream-cached";
+    private static final String STREAM_NAME = Optional.ofNullable(System.getProperty("kvs-stream")).orElse("my-stream-cached");
     private static final int FPS_25 = 25;
     private static final int RETENTION_ONE_HOUR = 1;
     private static final String IMAGE_DIR = "src/main/resources/data/h264/";
     private static final String FRAME_DIR = "src/main/resources/data/audio-video-frames";
-    private static final int STREAM_DURATION_IN_MS = 10000;
+    private static final Duration DEFAULT_DURATION_TO_STREAM = Duration.ofSeconds(10);
+    private static final Duration DURATION_TO_STREAM = Optional.ofNullable(System.getProperty("stream-duration-ms"))
+            .map(value -> {
+                try {
+                    return Duration.ofMillis(Long.parseLong(value));
+                } catch (final NumberFormatException e) {
+                    log.error("Invalid stream-duration value: {}. Using default {} ms.", value, DEFAULT_DURATION_TO_STREAM.toMillis());
+                    return null;
+                }
+            })
+            .orElse(DEFAULT_DURATION_TO_STREAM);
     // CHECKSTYLE:SUPPRESS:LineLength
     // This is a reference pipline to extract frames. Need to get key frame configured properly so the output can be
     // decoded. h264 files can be decoded using gstreamer plugin
@@ -61,6 +79,7 @@ public final class DemoAppCachedInfo {
                     .withRegion(Regions.US_WEST_2.getName())
                     .withCredentialsProvider(new JavaCredentialsProviderImpl(awsCredentialsProvider))
                     .withStorageCallbacks(new DefaultStorageCallbacks())
+                    .withIPVersionFilter(IPVersionFilter.IPV4_AND_IPV6)
                     .build();
 
             final Logger log = LogManager.getLogger(DemoAppCachedInfo.class);
@@ -103,12 +122,10 @@ public final class DemoAppCachedInfo {
             // start streaming
             mediaSource2.start();
 
-            // Run for 10 seconds then stop
-            try {
-                Thread.sleep(STREAM_DURATION_IN_MS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            // Run for a while
+            log.info("Main thread sleeping {} ms.", DURATION_TO_STREAM.toMillis());
+            Thread.sleep(DURATION_TO_STREAM.toMillis());
+            log.info("Stopping stream...");
 
             // unregister stream from client and free client
             serviceCallbacks.removeStreamFromCache(streamName1);
@@ -117,7 +134,7 @@ public final class DemoAppCachedInfo {
             kinesisVideoClient.unregisterMediaSource(mediaSource2);
             kinesisVideoClient.free();
             executor.shutdown();
-        } catch (final KinesisVideoException e) {
+        } catch (final KinesisVideoException | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
@@ -25,9 +25,7 @@ import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
 import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
 import com.amazonaws.services.kinesisvideo.model.GetDataEndpointResult;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.logging.log4j.core.config.Configurator;
 
-import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Executors;
@@ -38,7 +36,7 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public final class DemoAppCachedInfo {
 
-    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger log = LogManager.getLogger(DemoAppCachedInfo.class);
 
     // Use a different stream name when testing audio/video sample
     private static final String STREAM_NAME = Optional.ofNullable(System.getProperty("kvs-stream")).orElse("my-stream-cached");

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java
@@ -14,9 +14,7 @@ import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSourceConf
 import com.amazonaws.regions.Regions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.Configurator;
 
-import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -27,7 +25,7 @@ import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.ABSOLUTE_TIMEC
  */
 public final class DemoAppMain {
 
-    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger log = LogManager.getLogger(DemoAppMain.class);
 
     // Use a different stream name when testing audio/video sample
     private static final String STREAM_NAME = Optional.ofNullable(System.getProperty("kvs-stream")).orElse("");

--- a/src/main/java/com/amazonaws/kinesisvideo/client/IPVersionFilter.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/IPVersionFilter.java
@@ -1,0 +1,21 @@
+package com.amazonaws.kinesisvideo.client;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+
+public enum IPVersionFilter {
+    IPV4_AND_IPV6,   // Allows both IPv4 and IPv6
+    IPV4,            // Allows only IPv4
+    IPV6;            // Allows only IPv6
+
+    public boolean matches(final InetAddress address) {
+        if (this == IPV4) {
+            return address instanceof Inet4Address;
+        } else if (this == IPV6) {
+            return address instanceof Inet6Address;
+        } else {
+            return address instanceof Inet4Address || address instanceof Inet6Address;
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
@@ -2,48 +2,62 @@ package com.amazonaws.kinesisvideo.client;
 
 import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
 import com.amazonaws.kinesisvideo.producer.StorageCallbacks;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 
 /**
  * Configuration for KinesisVideoClient.
  */
 public final class KinesisVideoClientConfiguration {
+
+    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
     private final String region;
     private final KinesisVideoCredentialsProvider credentialsProvider;
     private final StorageCallbacks storageCallbacks;
     private final String endpoint;
-
+    private final IPVersionFilter ipVersionFilter;
     private KinesisVideoClientConfiguration(final Builder builder) {
         this.region = builder.region;
         this.credentialsProvider = builder.credentialsProvider;
         this.storageCallbacks = builder.storageCallbacks;
         this.endpoint = builder.endpoint;
+        this.ipVersionFilter = builder.ipVersionFilter;
     }
 
     public static Builder builder() {
         return new Builder();
     }
 
-    private static void sanitizeBuilder(final Builder builder) {
-        final String region = builder.region;
-        final String endpoint = builder.endpoint;
+    private static void sanitizeBuilder(@Nonnull final Builder builder) {
+        final boolean isLegacyEndpoint = builder.isLegacyEndpoint.orElse(KinesisVideoClientConfigurationDefaults.USE_LEGACY_ENDPOINT);
 
-        if (region == null && endpoint == null) {
+        if (builder.region == null && builder.endpoint == null) {
             builder.withRegion(KinesisVideoClientConfigurationDefaults.US_WEST_2);
-            builder.withEndpoint(KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(builder.region));
+            builder.withEndpoint(KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(builder.region, isLegacyEndpoint));
+
+            log.info("Using default region: {}", builder.region);
         }
 
-        if (region == null) {
+        if (builder.region == null) {
             // TODO: determine from endpoint?
             builder.withRegion(KinesisVideoClientConfigurationDefaults.US_WEST_2);
+            log.info("Using default region: {}", builder.region);
         }
 
-        if (endpoint == null) {
-            builder.withEndpoint(constructEndpoint(region));
+        if (builder.endpoint == null) {
+            builder.withEndpoint(KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(builder.region, isLegacyEndpoint));
         }
-    }
 
-    private static String constructEndpoint(final String region) {
-        return KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(region);
+        if (builder.ipVersionFilter == null) {
+            builder.withIPVersionFilter(KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6);
+        }
+
+        builder.withIsLegacyEndpoint(isLegacyEndpoint);
     }
 
     public String getServiceName() {
@@ -66,12 +80,27 @@ public final class KinesisVideoClientConfiguration {
         return this.endpoint;
     }
 
+    public IPVersionFilter getIpVersionFilter() { return this.ipVersionFilter; }
+
+    @Override
+    public String toString() {
+        return "KinesisVideoClientConfiguration{" +
+                "region='" + region + '\'' +
+                ", credentialsProvider=" + (credentialsProvider != null ? credentialsProvider.getClass().getSimpleName() : "null") +
+                ", storageCallbacks=" + (storageCallbacks != null ? storageCallbacks.getClass().getSimpleName() : "null") +
+                ", endpoint='" + endpoint + '\'' +
+                ", ipVersionFilter=" + ipVersionFilter +
+                '}';
+    }
+
     public static class Builder {
         private String region;
         private KinesisVideoCredentialsProvider credentialsProvider;
         private StorageCallbacks storageCallbacks =
                 KinesisVideoClientConfigurationDefaults.NO_OP_STORAGE_CALLBACKS;
         private String endpoint;
+        private Optional<Boolean> isLegacyEndpoint = Optional.empty();
+        private IPVersionFilter ipVersionFilter;
 
         public Builder withRegion(final String region) {
             this.region = region;
@@ -90,6 +119,16 @@ public final class KinesisVideoClientConfiguration {
 
         public Builder withEndpoint(final String endpoint) {
             this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder withIsLegacyEndpoint(final boolean isLegacyEndpoint) {
+            this.isLegacyEndpoint = Optional.of(isLegacyEndpoint);
+            return this;
+        }
+
+        public Builder withIPVersionFilter(final IPVersionFilter ipVersionFilter) {
+            this.ipVersionFilter = ipVersionFilter;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
-import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
 /**
@@ -14,13 +13,14 @@ import java.util.Optional;
  */
 public final class KinesisVideoClientConfiguration {
 
-    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger log = LogManager.getLogger(KinesisVideoClientConfiguration.class);
 
     private final String region;
     private final KinesisVideoCredentialsProvider credentialsProvider;
     private final StorageCallbacks storageCallbacks;
     private final String endpoint;
     private final IPVersionFilter ipVersionFilter;
+
     private KinesisVideoClientConfiguration(final Builder builder) {
         this.region = builder.region;
         this.credentialsProvider = builder.credentialsProvider;
@@ -38,7 +38,14 @@ public final class KinesisVideoClientConfiguration {
 
         if (builder.region == null && builder.endpoint == null) {
             builder.withRegion(KinesisVideoClientConfigurationDefaults.US_WEST_2);
-            builder.withEndpoint(KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(builder.region, isLegacyEndpoint));
+
+            if (isLegacyEndpoint) {
+                builder.withEndpoint(KinesisVideoClientConfigurationDefaults
+                        .getControlPlaneEndpoint(builder.region));
+            } else {
+                builder.withEndpoint(KinesisVideoClientConfigurationDefaults
+                        .getDualStackControlPlaneEndpoint(builder.region));
+            }
 
             log.info("Using default region: {}", builder.region);
         }
@@ -50,7 +57,13 @@ public final class KinesisVideoClientConfiguration {
         }
 
         if (builder.endpoint == null) {
-            builder.withEndpoint(KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(builder.region, isLegacyEndpoint));
+            if (isLegacyEndpoint) {
+                builder.withEndpoint(KinesisVideoClientConfigurationDefaults
+                        .getControlPlaneEndpoint(builder.region));
+            } else {
+                builder.withEndpoint(KinesisVideoClientConfigurationDefaults
+                        .getDualStackControlPlaneEndpoint(builder.region));
+            }
         }
 
         if (builder.ipVersionFilter == null) {
@@ -80,7 +93,9 @@ public final class KinesisVideoClientConfiguration {
         return this.endpoint;
     }
 
-    public IPVersionFilter getIpVersionFilter() { return this.ipVersionFilter; }
+    public IPVersionFilter getIpVersionFilter() {
+        return this.ipVersionFilter;
+    }
 
     @Override
     public String toString() {
@@ -122,8 +137,8 @@ public final class KinesisVideoClientConfiguration {
             return this;
         }
 
-        public Builder withIsLegacyEndpoint(final boolean isLegacyEndpoint) {
-            this.isLegacyEndpoint = Optional.of(isLegacyEndpoint);
+        public Builder withIsLegacyEndpoint(final Boolean isLegacyEndpoint) {
+            this.isLegacyEndpoint = Optional.ofNullable(isLegacyEndpoint);
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaults.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaults.java
@@ -8,6 +8,12 @@ import javax.annotation.Nonnull;
 public final class KinesisVideoClientConfigurationDefaults {
     static final String US_WEST_2 = "us-west-2";
     static final String PROD_CONTROL_PLANE_ENDPOINT_FORMAT = "kinesisvideo.%s.amazonaws.com";
+    static final String PROD_CONTROL_PLANE_ENDPOINT_FORMAT_CN = "kinesisvideo.%s.amazonaws.com.cn";
+    static final String PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK = "kinesisvideo.%s.api.aws";
+    static final String PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK_CN = "kinesisvideo.%s.api.amazonwebservices.com.cn";
+    static final boolean USE_LEGACY_ENDPOINT = true;
+
+    public static final IPVersionFilter BOTH_IPV4_AND_IPV6 = IPVersionFilter.IPV4_AND_IPV6; // Basically no filter
 
     static final int DEVICE_VERSION = 0;
     static final int TEN_STREAMS = 10;
@@ -18,8 +24,35 @@ public final class KinesisVideoClientConfigurationDefaults {
 
     static final StorageCallbacks NO_OP_STORAGE_CALLBACKS = new DefaultStorageCallbacks();
 
+    /**
+     * Construct KVS control plane legacy endpoint (excluding {@code https://}).
+     *
+     * @param region region
+     * @return legacy endpoint host name
+     */
     public static String getControlPlaneEndpoint(final @Nonnull String region) {
+        if (region.startsWith("cn-")) {
+            return String.format(PROD_CONTROL_PLANE_ENDPOINT_FORMAT_CN, region);
+        }
         return String.format(PROD_CONTROL_PLANE_ENDPOINT_FORMAT, region);
+    }
+
+    /**
+     * Construct either the KVS control plane legacy or dual-stack endpoint (excluding {@code https://}).
+     *
+     * @param region region
+     * @param isLegacyEndpoint which endpoint to construct (false = dual-stack)
+     * @return endpoint host name
+     */
+    public static String getControlPlaneEndpoint(final @Nonnull String region, final boolean isLegacyEndpoint) {
+        if (isLegacyEndpoint) {
+            return getControlPlaneEndpoint(region);
+        }
+
+        if (region.startsWith("cn-")) {
+            return String.format(PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK_CN, region);
+        }
+        return String.format(PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK, region);
     }
 
     private KinesisVideoClientConfigurationDefaults() {

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaults.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaults.java
@@ -38,17 +38,12 @@ public final class KinesisVideoClientConfigurationDefaults {
     }
 
     /**
-     * Construct either the KVS control plane legacy or dual-stack endpoint (excluding {@code https://}).
+     * Construct the KVS dual-stack endpoint (excluding {@code https://}).
      *
      * @param region region
-     * @param isLegacyEndpoint which endpoint to construct (false = dual-stack)
      * @return endpoint host name
      */
-    public static String getControlPlaneEndpoint(final @Nonnull String region, final boolean isLegacyEndpoint) {
-        if (isLegacyEndpoint) {
-            return getControlPlaneEndpoint(region);
-        }
-
+    public static String getDualStackControlPlaneEndpoint(final @Nonnull String region) {
         if (region.startsWith("cn-")) {
             return String.format(PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK_CN, region);
         }

--- a/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
@@ -76,6 +76,7 @@ public final class PutMediaClient {
         clientBuilder.header(FRAGMENT_TIME_CODE_TYPE_HEADER, mBuilder.mFragmentTimecodeType);
         clientBuilder.completionCallback(mBuilder.mCompletion);
         clientBuilder.setSenderCallback(sender);
+        clientBuilder.setIPVersionFilter(mBuilder.mIPVersionFilter);
         // Timeout if no response is received from the server for put(i.e., acks)
         // Socket will/should be closed by the consumer by throwing the SocketTimeoutException
         clientBuilder.setTimeout(mBuilder.mReceiveTimeout);
@@ -221,6 +222,7 @@ public final class PutMediaClient {
         private Consumer<Exception> mCompletion;
         // TODO: Set to correct output channel
         private Map<String, String> unsignedHeaders;
+        private IPVersionFilter mIPVersionFilter;
 
         public Builder putMediaDestinationUri(final URI uri) {
             mUri = uri;
@@ -287,6 +289,11 @@ public final class PutMediaClient {
 
         public Builder upstreamKbps(final long kbps) {
             upstreamKbps = kbps;
+            return this;
+        }
+
+        public Builder ipVersionFilter(final IPVersionFilter ipVersionFilter) {
+            mIPVersionFilter = ipVersionFilter;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/config/ClientConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/config/ClientConfiguration.java
@@ -1,5 +1,8 @@
 package com.amazonaws.kinesisvideo.config;
 
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults;
+
 import java.net.URI;
 
 public final class ClientConfiguration {
@@ -11,8 +14,9 @@ public final class ClientConfiguration {
     private URI streamUri;
     private Integer connectionTimeoutInMillis;
     private Integer readTimeoutInMillis;
+    private IPVersionFilter ipVersionFilter;
 
-    ClientConfiguration(final String region, final String serviceName, final String apiName, final String materialSet, final String streamName, final URI streamUri, final Integer connectionTimeoutInMillis, final Integer readTimeoutInMillis) {
+    ClientConfiguration(final String region, final String serviceName, final String apiName, final String materialSet, final String streamName, final URI streamUri, final Integer connectionTimeoutInMillis, final Integer readTimeoutInMillis, final IPVersionFilter ipVersionFilter) {
         this.region = region;
         this.serviceName = serviceName;
         this.apiName = apiName;
@@ -33,6 +37,7 @@ public final class ClientConfiguration {
         private URI streamUri;
         private Integer connectionTimeoutInMillis;
         private Integer readTimeoutInMillis;
+        private IPVersionFilter ipVersionFilter;
 
         ClientConfigurationBuilder() {
         }
@@ -77,13 +82,21 @@ public final class ClientConfiguration {
             return this;
         }
 
+        public ClientConfigurationBuilder ipVersionFilter(final IPVersionFilter ipVersionFilter) {
+            this.ipVersionFilter = ipVersionFilter;
+            return this;
+        }
+
         public ClientConfiguration build() {
-            return new ClientConfiguration(region, serviceName, apiName, materialSet, streamName, streamUri, connectionTimeoutInMillis, readTimeoutInMillis);
+            if (ipVersionFilter == null) {
+                this.ipVersionFilter = KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6;
+            }
+            return new ClientConfiguration(region, serviceName, apiName, materialSet, streamName, streamUri, connectionTimeoutInMillis, readTimeoutInMillis, ipVersionFilter);
         }
 
         @Override
         public String toString() {
-            return "ClientConfiguration.ClientConfigurationBuilder(region=" + this.region + ", serviceName=" + this.serviceName + ", apiName=" + this.apiName + ", materialSet=" + this.materialSet + ", streamName=" + this.streamName + ", streamUri=" + this.streamUri + ", connectionTimeoutInMillis=" + this.connectionTimeoutInMillis + ", readTimeoutInMillis=" + this.readTimeoutInMillis + ")";
+            return "ClientConfiguration.ClientConfigurationBuilder(region=" + this.region + ", serviceName=" + this.serviceName + ", apiName=" + this.apiName + ", materialSet=" + this.materialSet + ", streamName=" + this.streamName + ", streamUri=" + this.streamUri + ", connectionTimeoutInMillis=" + this.connectionTimeoutInMillis + ", readTimeoutInMillis=" + this.readTimeoutInMillis + ", ipVersionFilter=" + this.ipVersionFilter + ")";
         }
     }
 
@@ -121,6 +134,9 @@ public final class ClientConfiguration {
 
     public Integer getReadTimeoutInMillis() {
         return this.readTimeoutInMillis;
+    }
+    public IPVersionFilter getIpVersionFilter() {
+        return this.ipVersionFilter;
     }
 
     @Override

--- a/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/HostnameVerifyingX509ExtendedTrustManager.java
@@ -27,7 +27,7 @@ import java.security.cert.X509Certificate;
 
      A custom TrustManager that supports hostname verification via org.apache.http.conn.ssl.DefaultHostnameVerifier.
      *
-     * We attempt to perform verification using just the IP address first and if that fails will attempt to perform a
+     * We attempt to perform verification using just the IP address first (skippable) and if that fails will attempt to perform a
      * reverse DNS lookup and verify using the hostname.
 */
 
@@ -37,12 +37,20 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
             PublicSuffixMatcherLoader.getDefault());
     private Logger log = LogManager.getLogger(HostnameVerifyingX509ExtendedTrustManager.class);
     private final boolean clientSideHostnameVerificationEnabled;
+    private final boolean skipHostAddressVerification;
 
     private final X509ExtendedTrustManager x509ExtendedTrustManager;
 
     public HostnameVerifyingX509ExtendedTrustManager(final boolean clientSideHostnameVerificationEnabled) {
+        this(clientSideHostnameVerificationEnabled, false);
+    }
+
+    public HostnameVerifyingX509ExtendedTrustManager(
+            final boolean clientSideHostnameVerificationEnabled,
+            final boolean skipHostAddressVerification) {
         this.x509ExtendedTrustManager = getX509ExtendedTrustManager();
         this.clientSideHostnameVerificationEnabled = clientSideHostnameVerificationEnabled;
+        this.skipHostAddressVerification = skipHostAddressVerification;
     }
 
     private X509ExtendedTrustManager getX509ExtendedTrustManager() {
@@ -56,7 +64,7 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
             throw new RuntimeException("Unable to initialize default TrustManagerFactory", nse);
         }
 
-        for (TrustManager tm: factory.getTrustManagers()) {
+        for (TrustManager tm : factory.getTrustManagers()) {
             if (tm instanceof X509ExtendedTrustManager) {
                 return (X509ExtendedTrustManager) tm;
             }
@@ -146,9 +154,11 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
     /**
      * Compares peer's hostname with the one stored in the provided client certificate. Performs verification
      * with the help of provided HostnameVerifier.
+     * We attempt to perform verification using just the IP address first (skippable) and if that fails will
+     * attempt to perform a reverse DNS lookup and verify using the hostname.
      *
      * @param hostAddress Peer's host address.
-     * @param hostName Peer's host name.
+     * @param hostName    Peer's host name.
      * @param certificate Peer's certificate
      * @throws CertificateException Thrown if the provided certificate doesn't match the peer hostname.
      */
@@ -157,21 +167,29 @@ public class HostnameVerifyingX509ExtendedTrustManager extends X509ExtendedTrust
             final String hostName,
             final X509Certificate certificate
     ) throws CertificateException {
-        try {
-            DEFAULT_HOSTNAME_VERIFIER.verify(hostAddress, certificate);
-        } catch (SSLException addressVerificationException) {
+        SSLException addressVerificationException = null;
+        if (!skipHostAddressVerification) {
             try {
+                DEFAULT_HOSTNAME_VERIFIER.verify(hostAddress, certificate);
+                return;
+            } catch (final SSLException ex) {
+                addressVerificationException = ex;
                 log.debug(
                         "Failed to verify host address: {} attempting to verify host name with reverse dns lookup {}",
                         hostAddress,
                         addressVerificationException);
-                DEFAULT_HOSTNAME_VERIFIER.verify(hostName, certificate);
-            } catch (SSLException hostnameVerificationException) {
-                log.error("Failed to verify host address: {}", hostAddress, addressVerificationException);
-                log.error("Failed to verify hostname: {}", hostName, hostnameVerificationException);
-                throw new CertificateException("Failed to verify both host address and host name",
-                        hostnameVerificationException);
             }
+        }
+
+        try {
+            DEFAULT_HOSTNAME_VERIFIER.verify(hostName, certificate);
+        } catch (final SSLException hostnameVerificationException) {
+            if (!skipHostAddressVerification) {
+                log.error("Failed to verify host address: {}", hostAddress, addressVerificationException);
+            }
+            log.error("Failed to verify hostname: {}", hostName, hostnameVerificationException);
+            throw new CertificateException("Failed to verify both host address and host name",
+                    hostnameVerificationException);
         }
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/http/HttpClientBase.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/HttpClientBase.java
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults;
 import org.apache.http.entity.ContentType;
 
 public abstract class HttpClientBase implements HttpClient {
@@ -67,6 +69,7 @@ public abstract class HttpClientBase implements HttpClient {
         protected int mSocketTimeoutInMillis;
         protected ContentType mContentType;
         protected String mContentInJson;
+        protected IPVersionFilter mIPVersionFilter;
         
         public abstract T builderType();
 
@@ -74,6 +77,7 @@ public abstract class HttpClientBase implements HttpClient {
             mHeaders = new HashMap<String, String>();
             mConnectionTimeoutInMillis = DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS;
             mSocketTimeoutInMillis = DEFAULT_SOCKET_TIMEOUT_IN_MILLIS;
+            mIPVersionFilter = KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6;
         }
 
         public T withUri(final URI uri) {
@@ -109,6 +113,11 @@ public abstract class HttpClientBase implements HttpClient {
 
         public T withContentInJson(final String contentInJson) {
             mContentInJson = contentInJson;
+            return builderType();
+        }
+
+        public T withIpVersionFilter(final IPVersionFilter ipVersionFilter) {
+            mIPVersionFilter = ipVersionFilter;
             return builderType();
         }
     } 

--- a/src/main/java/com/amazonaws/kinesisvideo/http/KinesisVideoApacheHttpClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/KinesisVideoApacheHttpClient.java
@@ -39,7 +39,6 @@ public final class KinesisVideoApacheHttpClient extends HttpClientBase {
     }
 
     public CloseableHttpResponse executeRequest() {
-
         final HttpPost request = new HttpPost(mBuilder.mUri);
         for (Map.Entry<String, String> entry : mBuilder.mHeaders.entrySet()) {
             request.addHeader(entry.getKey(), entry.getValue());
@@ -56,7 +55,7 @@ public final class KinesisVideoApacheHttpClient extends HttpClientBase {
     private CloseableHttpClient buildHttpClient() {
         try {
             final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-            sslContext.init(null, new X509ExtendedTrustManager[] {
+            sslContext.init(null, new X509ExtendedTrustManager[]{
                     new HostnameVerifyingX509ExtendedTrustManager(true)}, new SecureRandom());
 
             final SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);
@@ -69,6 +68,7 @@ public final class KinesisVideoApacheHttpClient extends HttpClientBase {
                     .setDefaultSocketConfig(SocketConfig.custom()
                             .setSoTimeout(mBuilder.mSocketTimeoutInMillis)
                             .build())
+                    .setDnsResolver(new KvsFilteredDnsResolver(mBuilder.mIPVersionFilter))
                     .build();
         } catch (final KeyManagementException e) {
             throw new RuntimeException("Exception while building Apache http client", e);
@@ -81,9 +81,9 @@ public final class KinesisVideoApacheHttpClient extends HttpClientBase {
     public void closeClient() throws IOException {
         this.mHttpClient.close();
     }
-    
+
     public static final class Builder extends BuilderBase<Builder> {
-        
+
         public KinesisVideoApacheHttpClient build() {
             checkNotNull(mUri);
             return new KinesisVideoApacheHttpClient(this);

--- a/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
@@ -1,0 +1,69 @@
+package com.amazonaws.kinesisvideo.http;
+
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.invoke.MethodHandles;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+/**
+ * A DNS resolver that applies an IP version filter when resolving hostnames.
+ * This ensures that only IP addresses matching the specified filter are returned.
+ */
+public class KvsFilteredDnsResolver implements DnsResolver, com.amazonaws.DnsResolver {
+
+    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+    /** The IP version filter used for filtering resolved addresses. */
+    @Nonnull
+    private final IPVersionFilter ipVersionFilter;
+
+    /**
+     * Constructs a new {@code KvsFilteredDnsResolver} with the specified IP version filter.
+     *
+     * @param ipVersionFilter the IP version filter to apply; if {@code null}, defaults to {@link IPVersionFilter#IPV4_AND_IPV6}.
+     */
+    public KvsFilteredDnsResolver(@Nullable final IPVersionFilter ipVersionFilter) {
+        super();
+
+        if (ipVersionFilter != null) {
+            this.ipVersionFilter = ipVersionFilter;
+        } else {
+            // No filter, defaulting to allow both IPv4 and IPv6 (no filter)
+            this.ipVersionFilter = IPVersionFilter.IPV4_AND_IPV6;
+            log.debug("Defaulting to filter: {}", this.ipVersionFilter);
+        }
+    }
+
+    /**
+     * Resolves the given hostname and filters the results based on the configured {@link IPVersionFilter}.
+     *
+     * @param host the hostname to resolve
+     * @return an array of {@link InetAddress} containing only addresses that match the IP version filter
+     * @throws UnknownHostException if no matching addresses are found or if the hostname cannot be resolved
+     */
+    @Override
+    public InetAddress[] resolve(final String host) throws UnknownHostException {
+        log.debug("Resolving {}", host);
+        final InetAddress[] resolvedAddresses = Arrays.stream(SystemDefaultDnsResolver.INSTANCE.resolve(host))
+                .peek(inetAddr -> log.debug("Resolved IP: {}", inetAddr))
+                .filter(this.ipVersionFilter::matches)
+                .toArray(InetAddress[]::new);
+
+        if (resolvedAddresses.length == 0) {
+            throw new UnknownHostException("Not able to resolve any " + ipVersionFilter + " addresses for " + host + "!");
+        }
+
+        log.debug("{} filtered IP's: {}", ipVersionFilter, Arrays.toString(resolvedAddresses));
+
+        // Will always return an array with at least 1 element
+        return resolvedAddresses;
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
  */
 public class KvsFilteredDnsResolver implements DnsResolver, com.amazonaws.DnsResolver {
 
-    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger log = LogManager.getLogger(KvsFilteredDnsResolver.class);
 
     /** The IP version filter used for filtering resolved addresses. */
     @Nonnull

--- a/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolver.java
@@ -25,6 +25,8 @@ public class KvsFilteredDnsResolver implements DnsResolver, com.amazonaws.DnsRes
     @Nonnull
     private final IPVersionFilter ipVersionFilter;
 
+    private DnsResolver dnsResolver = SystemDefaultDnsResolver.INSTANCE;
+
     /**
      * Constructs a new {@code KvsFilteredDnsResolver} with the specified IP version filter.
      *
@@ -52,7 +54,7 @@ public class KvsFilteredDnsResolver implements DnsResolver, com.amazonaws.DnsRes
     @Override
     public InetAddress[] resolve(final String host) throws UnknownHostException {
         log.debug("Resolving {}", host);
-        final InetAddress[] resolvedAddresses = Arrays.stream(SystemDefaultDnsResolver.INSTANCE.resolve(host))
+        final InetAddress[] resolvedAddresses = Arrays.stream(dnsResolver.resolve(host))
                 .peek(inetAddr -> log.debug("Resolved IP: {}", inetAddr))
                 .filter(this.ipVersionFilter::matches)
                 .toArray(InetAddress[]::new);
@@ -65,5 +67,10 @@ public class KvsFilteredDnsResolver implements DnsResolver, com.amazonaws.DnsRes
 
         // Will always return an array with at least 1 element
         return resolvedAddresses;
+    }
+
+    // Override the default DNS resolver. Used in the tests.
+    protected void setDnsResolver(final DnsResolver dnsResolver) {
+        this.dnsResolver = dnsResolver;
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
@@ -1,11 +1,12 @@
 package com.amazonaws.kinesisvideo.http;
 
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults;
 import com.amazonaws.kinesisvideo.common.function.Consumer;
+import com.amazonaws.kinesisvideo.socket.SocketFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import com.amazonaws.kinesisvideo.socket.SocketFactory;
 
-import static com.amazonaws.kinesisvideo.common.preconditions.Preconditions.checkNotNull;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static com.amazonaws.kinesisvideo.common.preconditions.Preconditions.checkNotNull;
 
 public final class ParallelSimpleHttpClient implements HttpClient {
     private static final String SPACE = " ";
@@ -66,7 +69,7 @@ public final class ParallelSimpleHttpClient implements HttpClient {
     }
 
     private void initSocket() throws IOException {
-        mSocket = new SocketFactory().createSocket(mBuilder.mUri);
+        mSocket = new SocketFactory().createSocket(mBuilder.mUri, mBuilder.mIPVersionFilter);
         if (mBuilder.mTimeout != null) {
             mSocket.setSoTimeout(mBuilder.mTimeout);
         }
@@ -214,13 +217,15 @@ public final class ParallelSimpleHttpClient implements HttpClient {
         private Consumer<OutputStream> mSender;
         private Consumer<InputStream> mReceiver;
         private Integer mTimeout;
+        private IPVersionFilter mIPVersionFilter;
         private Consumer<Exception> mCompletion;
         // TODO: Set to correct output channel
 
         private Builder() {
-            mHeaders = new HashMap<String, String>();
+            mHeaders = new HashMap<>();
             mSender = NO_OP_SENDER;
             mCompletion = NO_OP_COMPLETION;
+            mIPVersionFilter = KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6;
         }
 
         public Builder uri(final URI uri) {
@@ -259,6 +264,11 @@ public final class ParallelSimpleHttpClient implements HttpClient {
 
         public Builder setTimeout(final Integer timeout) {
             mTimeout = timeout;
+            return this;
+        }
+
+        public Builder setIPVersionFilter(final IPVersionFilter ipVersionFilter) {
+            mIPVersionFilter = ipVersionFilter;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
@@ -52,7 +52,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
     /**
      * Name of the native library
      */
-    private static final String PRODUCER_NATIVE_LIBRARY_NAME = "KinesisVideoProducerJNI";
+    public static final String PRODUCER_NATIVE_LIBRARY_NAME = "KinesisVideoProducerJNI";
 
     /**
      * The expected library version.

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
@@ -148,6 +148,7 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
 
         try {
             this.kinesisVideoServiceClient.initialize(configuration);
+            log.debug("Initialized service client with configuration {}", configuration);
         } catch (final KinesisVideoException e) {
             log.error(e);
         }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
@@ -6,6 +6,7 @@ import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
@@ -37,7 +38,7 @@ public final class KinesisVideoJavaClientFactory {
     private static final String STORAGE_PATH = "/tmp";
     private static final int NUMBER_OF_THREADS_IN_POOL = 2;
 
-    private static final Logger log = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger log = LogManager.getLogger(KinesisVideoJavaClientFactory.class);
 
     private KinesisVideoJavaClientFactory() {
         throw new UnsupportedOperationException();
@@ -83,7 +84,7 @@ public final class KinesisVideoJavaClientFactory {
             @Nonnull final String endpointOverride,
             @Nullable final IPVersionFilter ipVersionFilter)
             throws KinesisVideoException {
-        return createKinesisVideoClient(regions, awsCredentialsProvider, endpointOverride, false, ipVersionFilter);
+        return createKinesisVideoClient(regions, awsCredentialsProvider, endpointOverride, null, ipVersionFilter);
     }
 
     /**
@@ -94,7 +95,7 @@ public final class KinesisVideoJavaClientFactory {
             @Nonnull final Regions regions,
             @Nonnull final AWSCredentialsProvider awsCredentialsProvider,
             @Nullable final String endpointOverride,
-            final boolean isLegacyEndpoint,
+            @Nullable final Boolean isLegacyEndpoint,
             @Nullable final IPVersionFilter ipVersionFilter)
             throws KinesisVideoException {
         Preconditions.checkNotNull(regions);
@@ -112,7 +113,7 @@ public final class KinesisVideoJavaClientFactory {
             builder.withIPVersionFilter(ipVersionFilter);
         }
 
-        if (endpointOverride != null && !endpointOverride.isEmpty()) {
+        if (!StringUtils.isNullOrEmpty(endpointOverride)) {
             builder.withEndpoint(endpointOverride);
         } else {
             builder.withIsLegacyEndpoint(isLegacyEndpoint);

--- a/src/main/java/com/amazonaws/kinesisvideo/socket/SocketFactory.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/socket/SocketFactory.java
@@ -1,6 +1,8 @@
 package com.amazonaws.kinesisvideo.socket;
 
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.http.HostnameVerifyingX509ExtendedTrustManager;
+import com.amazonaws.kinesisvideo.http.KvsFilteredDnsResolver;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -11,11 +13,22 @@ import java.net.Socket;
 import java.net.URI;
 import java.security.SecureRandom;
 
+/**
+ * A factory class for creating TCP and SSL sockets based on a given URI.
+ * It supports both HTTP and HTTPS connections and allows filtering of IP versions.
+ */
 public class SocketFactory {
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
     private static final KeyManager[] NO_KEY_MANAGERS = null;
 
+    /**
+     * Creates a socket for the given URI.
+     *
+     * @param uri The URI to connect to.
+     * @return A new {@link Socket} connected to the specified URI.
+     * @throws RuntimeException If an error occurs while creating the socket.
+     */
     public Socket createSocket(final URI uri) {
         try {
             return openSocket(uri);
@@ -24,8 +37,46 @@ public class SocketFactory {
         }
     }
 
+    /**
+     * Creates a socket for the given URI with an IP version filter.
+     *
+     * @param uri             The URI to connect to.
+     * @param ipVersionFilter The filter to use for resolving the host IP.
+     * @return A new {@link Socket} connected to the specified URI.
+     * @throws RuntimeException If an error occurs while creating the socket.
+     */
+    public Socket createSocket(final URI uri, final IPVersionFilter ipVersionFilter) {
+        try {
+            final InetAddress address = toInetAddr(uri, ipVersionFilter);
+
+            return openSocket(uri, address);
+        } catch (final Throwable e) {
+            throw new RuntimeException("Exception while creating socket !! ", e);
+        }
+    }
+
+    /**
+     * Opens a socket to the specified URI.
+     *
+     * @param uri The URI to connect to.
+     * @return A connected {@link Socket}.
+     * @throws Exception If an error occurs while opening the socket.
+     */
     private Socket openSocket(final URI uri) throws Exception {
         final InetAddress address = toInetAddr(uri);
+
+        return openSocket(uri, address);
+    }
+
+    /**
+     * Opens a socket to the specified URI and resolved address.
+     *
+     * @param uri     The URI to connect to.
+     * @param address The resolved {@link InetAddress} of the host.
+     * @return A connected {@link Socket}.
+     * @throws Exception If an error occurs while opening the socket.
+     */
+    private Socket openSocket(final URI uri, final InetAddress address) throws Exception {
         final int port = getPort(uri);
 
         return isHttps(uri)
@@ -33,25 +84,80 @@ public class SocketFactory {
                 : new Socket(address, port);
     }
 
+    /**
+     * Creates an SSL socket to the given address and port.
+     *
+     * @param address The target {@link InetAddress}.
+     * @param port    The port number.
+     * @return A secure {@link Socket} using TLSv1.2.
+     * @throws Exception If an error occurs while creating the SSL socket.
+     */
     private Socket createSslSocket(final InetAddress address, final int port) throws Exception {
         final SSLContext context = SSLContext.getInstance("TLSv1.2");
-        context.init(NO_KEY_MANAGERS, new X509ExtendedTrustManager[] {
-                new HostnameVerifyingX509ExtendedTrustManager(true)}, new SecureRandom());
+
+        // Skipping IP-based hostname verification to avoid unnecessary debug logs:
+        // e.g. "Certificate for <x.x.x.x> doesn't match any of the subject alternative names: [s-1234abcd.kinesisvideo.us-west-2.amazonaws.com]"
+        // The server certificate contains the hostname, not the raw IP address.
+        // Verifying against the IP is redundant in this case and causes misleading debug output.
+        context.init(NO_KEY_MANAGERS, new X509ExtendedTrustManager[]{
+                new HostnameVerifyingX509ExtendedTrustManager(true, true)},
+                new SecureRandom());
         return context.getSocketFactory().createSocket(address, port);
     }
 
+    /**
+     * Checks if the given URI uses HTTPS.
+     *
+     * @param uri The URI to check.
+     * @return {@code true} if the URI scheme is "https", otherwise {@code false}.
+     * @throws IllegalArgumentException if the URI scheme isn't "http" or "https".
+     */
     private boolean isHttps(final URI uri) {
+        if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Unsupported URI scheme: '" + uri.getScheme() + "' in URI: " + uri);
+        }
         return "https".equalsIgnoreCase(uri.getScheme());
     }
 
+    /**
+     * Resolves the hostname of the given URI to an {@link InetAddress}.
+     *
+     * @param uri The URI to resolve.
+     * @return The resolved {@link InetAddress}.
+     * @throws Exception If resolution fails.
+     */
     private InetAddress toInetAddr(final URI uri) throws Exception {
         return InetAddress.getByName(getHost(uri));
     }
 
+    /**
+     * Resolves the hostname of the given URI using an {@link IPVersionFilter}.
+     *
+     * @param uri      The URI to resolve.
+     * @param ipFilter The IP version filter.
+     * @return The resolved {@link InetAddress}.
+     * @throws Exception If resolution fails.
+     */
+    private InetAddress toInetAddr(final URI uri, final IPVersionFilter ipFilter) throws Exception {
+        return new KvsFilteredDnsResolver(ipFilter).resolve(uri.getHost())[0];
+    }
+
+    /**
+     * Retrieves the host from the given URI.
+     *
+     * @param uri The URI to extract the host from.
+     * @return The host as a {@link String}.
+     */
     private String getHost(final URI uri) {
         return uri.getHost();
     }
 
+    /**
+     * Determines the appropriate port for the given URI.
+     *
+     * @param uri The URI to extract the port from.
+     * @return The port number. Defaults to {@value DEFAULT_HTTPS_PORT} for HTTPS and {@value DEFAULT_HTTP_PORT} for HTTP if not specified in the URI.
+     */
     private int getPort(final URI uri) {
         if (uri.getPort() > 0) {
             return uri.getPort();

--- a/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaultsTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaultsTest.java
@@ -1,0 +1,54 @@
+package com.amazonaws.kinesisvideo.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class KinesisVideoClientConfigurationDefaultsTest {
+    private static final boolean LEGACY = true;
+    private static final boolean DUAL_STACK = false;
+
+    private final String region;
+    private final boolean isLegacyEndpoint;
+    private final String expectedEndpoint;
+
+    public KinesisVideoClientConfigurationDefaultsTest(final String region,
+                                                       final boolean isLegacyEndpoint,
+                                                       final String expectedEndpoint) {
+        this.region = region;
+        this.isLegacyEndpoint = isLegacyEndpoint;
+        this.expectedEndpoint = expectedEndpoint;
+    }
+
+    @Parameterized.Parameters(name = "{index}: getControlPlaneEndpoint({0}, {1}) => {2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                // Normal regions, legacy
+                {"us-west-2", LEGACY, "kinesisvideo.us-west-2.amazonaws.com"},
+                {"eu-central-1", LEGACY, "kinesisvideo.eu-central-1.amazonaws.com"},
+
+                // China regions, legacy
+                {"cn-north-1", LEGACY, "kinesisvideo.cn-north-1.amazonaws.com.cn"},
+                {"cn-northwest-1", LEGACY, "kinesisvideo.cn-northwest-1.amazonaws.com.cn"},
+
+                // Normal regions, dual stack
+                {"us-west-2", DUAL_STACK, "kinesisvideo.us-west-2.api.aws"},
+                {"eu-central-1", DUAL_STACK, "kinesisvideo.eu-central-1.api.aws"},
+
+                // China regions, dual stack
+                {"cn-north-1", DUAL_STACK, "kinesisvideo.cn-north-1.api.amazonwebservices.com.cn"},
+                {"cn-northwest-1", DUAL_STACK, "kinesisvideo.cn-northwest-1.api.amazonwebservices.com.cn"}
+        });
+    }
+
+    @Test
+    public void testGetControlPlaneEndpoint() {
+        assertEquals(expectedEndpoint, KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(region, isLegacyEndpoint));
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaultsTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationDefaultsTest.java
@@ -49,6 +49,12 @@ public class KinesisVideoClientConfigurationDefaultsTest {
 
     @Test
     public void testGetControlPlaneEndpoint() {
-        assertEquals(expectedEndpoint, KinesisVideoClientConfigurationDefaults.getControlPlaneEndpoint(region, isLegacyEndpoint));
+        if (isLegacyEndpoint) {
+            assertEquals(expectedEndpoint, KinesisVideoClientConfigurationDefaults
+                    .getControlPlaneEndpoint(region));
+        } else {
+            assertEquals(expectedEndpoint, KinesisVideoClientConfigurationDefaults
+                    .getDualStackControlPlaneEndpoint(region));
+        }
     }
 }

--- a/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
@@ -1,0 +1,114 @@
+package com.amazonaws.kinesisvideo.client;
+
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
+import com.amazonaws.kinesisvideo.producer.StorageCallbacks;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(Parameterized.class)
+public class KinesisVideoClientConfigurationTest {
+
+    private final String region;
+    private final String endpoint;
+    private final Boolean isLegacyEndpoint;
+    private final String expectedRegion;
+    private final String expectedEndpoint;
+
+    public KinesisVideoClientConfigurationTest(String region, String endpoint, Boolean isLegacyEndpoint,
+                                               String expectedRegion, String expectedEndpoint) {
+        this.region = region;
+        this.endpoint = endpoint;
+        this.isLegacyEndpoint = isLegacyEndpoint;
+        this.expectedRegion = expectedRegion;
+        this.expectedEndpoint = expectedEndpoint;
+    }
+
+    @Parameterized.Parameters(name = "{index}: region={0}, endpoint={1}, isLegacy={2} => expectedRegion={3}, expectedEndpoint={4}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                // Default values should be applied when no region/endpoint is provided
+                {null, null, true, "us-west-2", "kinesisvideo.us-west-2.amazonaws.com"},
+                {null, null, false, "us-west-2", "kinesisvideo.us-west-2.api.aws"},
+
+                // Specified region but no endpoint, SDK should construct the endpoint
+                {"eu-central-1", null, true, "eu-central-1", "kinesisvideo.eu-central-1.amazonaws.com"},
+                {"eu-central-1", null, false, "eu-central-1", "kinesisvideo.eu-central-1.api.aws"},
+
+                // If endpoint override provided, use that
+                {null, "custom-endpoint.amazonaws.com", true, "us-west-2", "custom-endpoint.amazonaws.com"},
+                {null, "custom-endpoint.api.aws", false, "us-west-2", "custom-endpoint.api.aws"},
+
+                // Check CN regions since they have a different format
+                {"cn-north-1", null, true, "cn-north-1", "kinesisvideo.cn-north-1.amazonaws.com.cn"},
+                {"cn-north-1", null, false, "cn-north-1", "kinesisvideo.cn-north-1.api.amazonwebservices.com.cn"},
+        });
+    }
+
+    @Test
+    public void testRegionAndEndpoint() {
+        KinesisVideoClientConfiguration.Builder builder = KinesisVideoClientConfiguration.builder();
+
+        if (region != null) {
+            builder.withRegion(region);
+        }
+        if (endpoint != null) {
+            builder.withEndpoint(endpoint);
+        }
+        if (isLegacyEndpoint != null) {
+            builder.withIsLegacyEndpoint(isLegacyEndpoint);
+        }
+
+        KinesisVideoClientConfiguration config = builder.build();
+
+        assertEquals(expectedRegion, config.getRegion());
+        assertEquals(expectedEndpoint, config.getEndpoint());
+    }
+
+    @Test
+    public void testCustomStorageCallbacks() {
+        StorageCallbacks mockStorageCallbacks = mock(StorageCallbacks.class);
+
+        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .withStorageCallbacks(mockStorageCallbacks)
+                .withIsLegacyEndpoint(true)
+                .build();
+
+        assertEquals(mockStorageCallbacks, config.getStorageCallbacks());
+    }
+
+    @Test
+    public void testCustomCredentialsProvider() {
+        KinesisVideoCredentialsProvider mockProvider = mock(KinesisVideoCredentialsProvider.class);
+
+        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .withCredentialsProvider(mockProvider)
+                .withIsLegacyEndpoint(true)
+                .build();
+
+        assertEquals(mockProvider, config.getCredentialsProvider());
+    }
+
+    @Test
+    public void testIpVersionDefault() {
+        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .build();
+
+        assertEquals(KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6, config.getIpVersionFilter());
+    }
+
+    @Test
+    public void testIpVersionSet() {
+        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .withIPVersionFilter(IPVersionFilter.IPV6)
+                .build();
+
+        assertEquals(IPVersionFilter.IPV6, config.getIpVersionFilter());
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
@@ -1,7 +1,13 @@
 package com.amazonaws.kinesisvideo.client;
 
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentials;
 import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
+import com.amazonaws.kinesisvideo.auth.StaticCredentialsProvider;
+import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
 import com.amazonaws.kinesisvideo.producer.StorageCallbacks;
+import com.amazonaws.kinesisvideo.storage.DefaultStorageCallbacks;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoPutMediaClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -10,6 +16,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -21,8 +29,8 @@ public class KinesisVideoClientConfigurationTest {
     private final String expectedRegion;
     private final String expectedEndpoint;
 
-    public KinesisVideoClientConfigurationTest(String region, String endpoint, Boolean isLegacyEndpoint,
-                                               String expectedRegion, String expectedEndpoint) {
+    public KinesisVideoClientConfigurationTest(final String region, final String endpoint, final Boolean isLegacyEndpoint,
+                                               final String expectedRegion, final String expectedEndpoint) {
         this.region = region;
         this.endpoint = endpoint;
         this.isLegacyEndpoint = isLegacyEndpoint;
@@ -53,7 +61,7 @@ public class KinesisVideoClientConfigurationTest {
 
     @Test
     public void testRegionAndEndpoint() {
-        KinesisVideoClientConfiguration.Builder builder = KinesisVideoClientConfiguration.builder();
+        final KinesisVideoClientConfiguration.Builder builder = KinesisVideoClientConfiguration.builder();
 
         if (region != null) {
             builder.withRegion(region);
@@ -65,7 +73,7 @@ public class KinesisVideoClientConfigurationTest {
             builder.withIsLegacyEndpoint(isLegacyEndpoint);
         }
 
-        KinesisVideoClientConfiguration config = builder.build();
+        final KinesisVideoClientConfiguration config = builder.build();
 
         assertEquals(expectedRegion, config.getRegion());
         assertEquals(expectedEndpoint, config.getEndpoint());
@@ -73,9 +81,9 @@ public class KinesisVideoClientConfigurationTest {
 
     @Test
     public void testCustomStorageCallbacks() {
-        StorageCallbacks mockStorageCallbacks = mock(StorageCallbacks.class);
+        final StorageCallbacks mockStorageCallbacks = mock(StorageCallbacks.class);
 
-        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
                 .withStorageCallbacks(mockStorageCallbacks)
                 .withIsLegacyEndpoint(true)
                 .build();
@@ -85,9 +93,9 @@ public class KinesisVideoClientConfigurationTest {
 
     @Test
     public void testCustomCredentialsProvider() {
-        KinesisVideoCredentialsProvider mockProvider = mock(KinesisVideoCredentialsProvider.class);
+        final KinesisVideoCredentialsProvider mockProvider = mock(KinesisVideoCredentialsProvider.class);
 
-        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
                 .withCredentialsProvider(mockProvider)
                 .withIsLegacyEndpoint(true)
                 .build();
@@ -97,7 +105,7 @@ public class KinesisVideoClientConfigurationTest {
 
     @Test
     public void testIpVersionDefault() {
-        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
                 .build();
 
         assertEquals(KinesisVideoClientConfigurationDefaults.BOTH_IPV4_AND_IPV6, config.getIpVersionFilter());
@@ -105,10 +113,51 @@ public class KinesisVideoClientConfigurationTest {
 
     @Test
     public void testIpVersionSet() {
-        KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
                 .withIPVersionFilter(IPVersionFilter.IPV6)
                 .build();
 
         assertEquals(IPVersionFilter.IPV6, config.getIpVersionFilter());
+    }
+
+    @Test
+    public void testToStringDoesntThrowNullPointerException() {
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder().build();
+        final String toStringOutput = config.toString();
+
+        // Ensure it's not the default Object.toString() output
+        // (which typically contains "@" and class name)
+        final boolean looksDefault = toStringOutput.matches(".*@\\p{XDigit}+");
+        assertFalse("Expected toString() to be overridden, but was " + toStringOutput, looksDefault);
+    }
+
+    @Test
+    public void testToStringIsNotDefaultImplementation() {
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .withCredentialsProvider(new StaticCredentialsProvider(new KinesisVideoCredentials("ak", "sk")))
+                .withStorageCallbacks(new DefaultStorageCallbacks())
+                .withRegion("us-east-1")
+                .withEndpoint("custom-endpoint.amazonaws.com")
+                .withIsLegacyEndpoint(true)
+                .build();
+
+        final String toStringOutput = config.toString();
+
+        // Ensure it's not the default Object.toString() output
+        // (which typically contains "@" and class name)
+        final boolean looksDefault = toStringOutput.matches(".*@\\p{XDigit}+");
+        assertFalse("Expected toString() to be overridden, but was " + toStringOutput, looksDefault);
+
+        // Sanity check it contains useful field info
+        assertTrue("Expected toString() to contain 'us-east-1'", toStringOutput.contains("us-east-1"));
+        assertTrue("Expected toString() to contain 'custom-endpoint' which was set", toStringOutput.contains("custom-endpoint"));
+    }
+
+    @Test
+    public void checkServiceName() {
+        final KinesisVideoClientConfiguration config = KinesisVideoClientConfiguration.builder()
+                .build();
+
+        assertEquals("kinesisvideo", config.getServiceName());
     }
 }

--- a/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfigurationTest.java
@@ -44,18 +44,22 @@ public class KinesisVideoClientConfigurationTest {
                 // Default values should be applied when no region/endpoint is provided
                 {null, null, true, "us-west-2", "kinesisvideo.us-west-2.amazonaws.com"},
                 {null, null, false, "us-west-2", "kinesisvideo.us-west-2.api.aws"},
+                {null, null, null, "us-west-2", "kinesisvideo.us-west-2.amazonaws.com"},
 
                 // Specified region but no endpoint, SDK should construct the endpoint
                 {"eu-central-1", null, true, "eu-central-1", "kinesisvideo.eu-central-1.amazonaws.com"},
                 {"eu-central-1", null, false, "eu-central-1", "kinesisvideo.eu-central-1.api.aws"},
+                {"eu-central-1", null, null, "eu-central-1", "kinesisvideo.eu-central-1.amazonaws.com"},
 
                 // If endpoint override provided, use that
                 {null, "custom-endpoint.amazonaws.com", true, "us-west-2", "custom-endpoint.amazonaws.com"},
                 {null, "custom-endpoint.api.aws", false, "us-west-2", "custom-endpoint.api.aws"},
+                {null, "custom-endpoint.amazonaws.com", null, "us-west-2", "custom-endpoint.amazonaws.com"},
 
                 // Check CN regions since they have a different format
                 {"cn-north-1", null, true, "cn-north-1", "kinesisvideo.cn-north-1.amazonaws.com.cn"},
                 {"cn-north-1", null, false, "cn-north-1", "kinesisvideo.cn-north-1.api.amazonwebservices.com.cn"},
+                {"cn-north-1", null, null, "cn-north-1", "kinesisvideo.cn-north-1.amazonaws.com.cn"},
         });
     }
 
@@ -138,7 +142,7 @@ public class KinesisVideoClientConfigurationTest {
                 .withStorageCallbacks(new DefaultStorageCallbacks())
                 .withRegion("us-east-1")
                 .withEndpoint("custom-endpoint.amazonaws.com")
-                .withIsLegacyEndpoint(true)
+                .withIsLegacyEndpoint(null)
                 .build();
 
         final String toStringOutput = config.toString();

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
@@ -2,8 +2,11 @@ package com.amazonaws.kinesisvideo.common;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import com.amazonaws.kinesisvideo.producer.StreamInfo;
@@ -16,6 +19,14 @@ public class ProducerApiTest extends ProducerTestBase{
 
     private static final int TEST_STREAM_COUNT = 10;
     private static final int TEST_START_STOP_ITERATION_COUNT = 200;
+
+    @Before
+    public void checkJNIAvailability() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+    }
 
     /**
      * This test attempts to create multiple streams, free them, re-create them, free them,
@@ -141,6 +152,13 @@ public class ProducerApiTest extends ProducerTestBase{
             testStreamName = "JavaProducerApiTestStream_createProduceStartStopStreamEndpointCached" + i;
             kinesisVideoProducerStreams[i] = createTestStream(testStreamName,
                     StreamInfo.StreamingType.STREAMING_TYPE_REALTIME, TEST_LATENCY, TEST_BUFFER_DURATION);
+
+            // A prefix might be appended in the createTestStream method, so the stream name may have
+            // gotten updated
+            assertNotNull(kinesisVideoProducerStreams[i].getStreamName());
+            assertTrue(kinesisVideoProducerStreams[i].getStreamName().endsWith(testStreamName));
+            testStreamName = kinesisVideoProducerStreams[i].getStreamName();
+
             cacheStreamingInfo(false, testStreamName); // used to cache the stream-endpoint.
             // first argument is set to false since we want to cache only the endpoint and not the stream-info
             // and the credential-provider
@@ -206,6 +224,13 @@ public class ProducerApiTest extends ProducerTestBase{
             testStreamName = "JavaProducerApiTestStream_createProduceStartStopStreamAllCached" + i;
             kinesisVideoProducerStreams[i] = createTestStream(testStreamName,
                     StreamInfo.StreamingType.STREAMING_TYPE_REALTIME, TEST_LATENCY, TEST_BUFFER_DURATION);
+
+            // A prefix might be appended in the createTestStream method, so the stream name may have
+            // gotten updated
+            assertNotNull(kinesisVideoProducerStreams[i].getStreamName());
+            assertTrue(kinesisVideoProducerStreams[i].getStreamName().endsWith(testStreamName));
+            testStreamName = kinesisVideoProducerStreams[i].getStreamName();
+
             cacheStreamingInfo(true, testStreamName);
             // first argument is true since we want to cache
             // all - the credential-provider, the stream-info and the stream-endpoint

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerFunctionalityTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerFunctionalityTest.java
@@ -1,28 +1,43 @@
 package com.amazonaws.kinesisvideo.common;
 
-import java.nio.ByteBuffer;
-
-import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Time;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
-import com.amazonaws.kinesisvideo.producer.*;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ProducerFunctionalityTest extends ProducerTestBase{
 
     final Logger log = LogManager.getLogger(ProducerFunctionalityTest.class);
+
+    @Before
+    public void checkJNIAvailability() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+    }
+
     /**
      * This test creates a stream, stops it and frees it
      */
     @Test
     public void startStopSyncTerminate() {
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
 
         storageInfo_ = new StorageInfo(0,
                 StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM, STORAGE_SIZE_MEGS,
@@ -36,7 +51,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         // uses the KinesisVideoProducer to create a stream
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }
@@ -51,11 +66,11 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
     public void offlineUploadLimitedBufferDuration() {
         int flags;
         long currentTimeMs = 0;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES],
         };
 
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
         storageInfo_ = new StorageInfo(0,
@@ -77,7 +92,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -85,7 +100,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         }
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -93,7 +108,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
 
@@ -123,11 +138,11 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
     public void offlineUploadLimitedStorage() {
         int flags;
         long currentTimeMs = System.currentTimeMillis() * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES * 12]
         };
 
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
         storageInfo_ = new StorageInfo(0,
@@ -148,7 +163,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -157,7 +172,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
 
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -165,7 +180,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }
@@ -187,14 +202,14 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
     public void intermittentFileUpload() {
         int flags;
         long currentTimeMs = 0;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES]
         };
-        int clipDurationSeconds = 15;
-        int clipCount = 20;
-        int framesPerClip = clipDurationSeconds * TEST_FPS;
-        int totalFrames = framesPerClip * clipCount;
-        int[] pauseBetweenClipSeconds = new int[]{2, 15};
+        final int clipDurationSeconds = 15;
+        final int clipCount = 20;
+        final int framesPerClip = clipDurationSeconds * TEST_FPS;
+        final int totalFrames = framesPerClip * clipCount;
+        final int[] pauseBetweenClipSeconds = new int[]{2, 15};
 
         KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
@@ -207,7 +222,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
 
         createProducer();
 
-        for(int pauseSeconds: pauseBetweenClipSeconds) {
+        for (final int pauseSeconds : pauseBetweenClipSeconds) {
 
             previousBufferingAckTimestamp_.clear();
             bufferingAckInSequence_ = true;
@@ -222,7 +237,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                         TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
                 try {
                     kinesisVideoProducerStream.putFrame(frame);
-                } catch(ProducerException e) {
+                } catch (final ProducerException e) {
                     e.printStackTrace();
                     fail();
                 }
@@ -231,7 +246,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                 if((index + 1) % framesPerClip == 0) { // pause on the last frame of each clip
                     try {
                         Thread.sleep(pauseSeconds * 1000);
-                    } catch(InterruptedException e) {
+                    } catch (final InterruptedException e) {
                         e.printStackTrace();
                         fail();
                     }
@@ -240,7 +255,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
 
             try {
                 Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-            } catch(InterruptedException e) {
+            } catch (final InterruptedException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -248,7 +263,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
             log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
             try {
                 kinesisVideoProducerStream.stopStreamSync();
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -273,11 +288,11 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
     public void highFragmentRateFileUpload() {
         int flags;
         long currentTimeMs = 0;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES]
         };
 
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
         storageInfo_ = new StorageInfo(0,
@@ -301,7 +316,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -309,7 +324,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         }
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -317,7 +332,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }
@@ -338,13 +353,13 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
     @Ignore
     @Test
     public void offlineModeTokenRotationBlockOnSpace() {
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
         int flags;
-        int testFrameTotalCount = 10 * 1000;
+        final int testFrameTotalCount = 10 * 1000;
         long currentTimeMs = System.currentTimeMillis() * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES]
         };
 
@@ -365,7 +380,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -373,7 +388,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         }
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -381,7 +396,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }
@@ -405,17 +420,17 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      */
     @Test
     public void realtimeIntermittentNoLatencyPressureEofr() {
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
         int flags;
-        int testFrameTotalCount;
+        final int testFrameTotalCount;
         long currentTimeMs = 0;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES]
         };
-        byte[][] eofrData = new byte[][]{ new byte[0] };
-        KinesisVideoFrame eofr = new KinesisVideoFrame(0, 8, 0, 0, 0,
+        final byte[][] eofrData = new byte[][]{new byte[0]};
+        final KinesisVideoFrame eofr = new KinesisVideoFrame(0, 8, 0, 0, 0,
                 ByteBuffer.wrap(eofrData[0 % eofrData.length]));
 
         storageInfo_ = new StorageInfo(0,
@@ -438,13 +453,13 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
             if(index == 5 * keyFrameInterval_) { // pause on the 5th key frame
                 try {
                     kinesisVideoProducerStream.putFrame(eofr);
-                } catch(ProducerException e) {
+                } catch (final ProducerException e) {
                     e.printStackTrace();
                     fail();
                 }
                 try {
                     Thread.sleep(60000); // make sure we hit the connection idle timeout of 60 seconds
-                } catch(InterruptedException e) {
+                } catch (final InterruptedException e) {
                     e.printStackTrace();
                     fail();
                 }
@@ -454,7 +469,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     TEST_FRAME_DURATION, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -462,7 +477,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
 
             try {
                 Thread.sleep(30);
-            } catch(InterruptedException e) {
+            } catch (final InterruptedException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -470,7 +485,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         }
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -478,7 +493,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }
@@ -498,13 +513,13 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      */
     @Test
     public void realtimeAutoIntermittentLatencyPressure() {
-        KinesisVideoProducerStream kinesisVideoProducerStream;
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
 
-        int totalFrameCount;
+        final int totalFrameCount;
         int flags;
         long currentTimeMs;
         long delta = 0;
-        byte[][] framesData = new byte[][]{
+        final byte[][] framesData = new byte[][]{
                 new byte[TEST_FRAME_SIZE_BYTES]
         };
 
@@ -531,10 +546,10 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
             flags = index % keyFrameInterval_ == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
             if(index == 5 * keyFrameInterval_) {
-                long start = System.currentTimeMillis();
+                final long start = System.currentTimeMillis();
                 try {
                     Thread.sleep(60000);
-                } catch(InterruptedException e) {
+                } catch (final InterruptedException e) {
                     e.printStackTrace();
                     fail();
                 }
@@ -546,14 +561,14 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
                     frameDuration_, ByteBuffer.wrap(framesData[index % framesData.length]));
             try {
                 kinesisVideoProducerStream.putFrame(frame);
-            } catch(ProducerException e) {
+            } catch (final ProducerException e) {
                 e.printStackTrace();
                 fail();
             }
 
             try {
                 Thread.sleep(frameDuration_ / 10000);
-            } catch(InterruptedException e) {
+            } catch (final InterruptedException e) {
                 e.printStackTrace();
                 fail();
             }
@@ -561,7 +576,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
 
         try {
             Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
-        } catch(InterruptedException e) {
+        } catch (final InterruptedException e) {
             e.printStackTrace();
             fail();
         }
@@ -569,7 +584,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
         log.debug("Stopping the stream: {}", kinesisVideoProducerStream.getStreamName());
         try {
             kinesisVideoProducerStream.stopStreamSync();
-        } catch(ProducerException e) {
+        } catch (final ProducerException e) {
             e.printStackTrace();
             fail();
         }

--- a/src/test/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolverTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/http/KvsFilteredDnsResolverTest.java
@@ -1,0 +1,25 @@
+package com.amazonaws.kinesisvideo.http;
+
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import org.apache.http.conn.DnsResolver;
+import org.junit.Test;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class KvsFilteredDnsResolverTest {
+
+    @Test(expected = UnknownHostException.class)
+    public void testResolve_withNonMatchingFilter_throwsException() throws Exception {
+        final KvsFilteredDnsResolver resolver = new KvsFilteredDnsResolver(IPVersionFilter.IPV4);
+
+        final DnsResolver fakeResolver = (host) -> new InetAddress[]{
+                Inet6Address.getByName("::1") // Mock IPv6 address
+        };
+
+        resolver.setDnsResolver(fakeResolver);
+
+        resolver.resolve("https://kinesisvideo.us-west-2.amazonaws.com");
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/socket/SocketFactoryTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/socket/SocketFactoryTest.java
@@ -1,0 +1,76 @@
+package com.amazonaws.kinesisvideo.socket;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SocketFactoryTest {
+
+    private static final int httpPort = 8080;
+    private static final int httpsPort = 8443;
+    private final SocketFactory socketFactory = new SocketFactory();
+
+    @Test
+    public void testCreateSocket_Http() throws Exception {
+        try (final ServerSocket server = new ServerSocket(httpPort)) {
+            final URI uri = new URI("http://localhost:" + httpPort);
+            final Socket socket = socketFactory.createSocket(uri);
+
+            assertNotNull(socket);
+            assertTrue(socket.isConnected());
+            assertEquals("localhost", socket.getInetAddress().getHostName());
+            assertEquals(httpPort, socket.getPort());
+        }
+    }
+
+    @Test
+    public void testCreateSocket_Https() throws Exception {
+        try (final ServerSocket server = new ServerSocket(httpsPort)) {
+            final URI uri = new URI("https://localhost:" + httpsPort);
+            final Socket socket = socketFactory.createSocket(uri);
+
+            assertNotNull(socket);
+            assertTrue(socket.isConnected());
+            assertEquals("localhost", socket.getInetAddress().getHostName());
+            assertEquals(httpsPort, socket.getPort());
+        }
+    }
+
+    @Test
+    public void testCreateSocket_InvalidURI() throws URISyntaxException, IOException {
+        try (final Socket socket = socketFactory.createSocket(new URI("invalid://localhost"))) {
+            fail("It should have thrown an exception");
+        } catch (final RuntimeException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test
+    public void testCreateSocket_UnreachablePort() throws URISyntaxException, IOException {
+        try (final Socket socket = socketFactory.createSocket(new URI("http://localhost:65535"))) {
+            fail("It should have thrown an exception");
+        } catch (final RuntimeException e) {
+            assertTrue(e.getCause() instanceof ConnectException);
+        }
+    }
+
+    @Test
+    public void testCreateSocket_NonExistentDomain() throws URISyntaxException, IOException {
+        try (final Socket socket = socketFactory.createSocket(new URI("http://nonexistent.example.com:80"))) {
+            fail("It should have thrown an exception");
+        } catch (final RuntimeException e) {
+            assertTrue(e.getCause() instanceof UnknownHostException);
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/socket/SocketWithIpFilterTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/socket/SocketWithIpFilterTest.java
@@ -1,0 +1,62 @@
+package com.amazonaws.kinesisvideo.socket;
+
+import com.amazonaws.kinesisvideo.client.IPVersionFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class SocketWithIpFilterTest {
+
+    private static final int httpPort = 8080;
+    private static final int httpsPort = 8443;
+
+    private final int port;
+    private final IPVersionFilter ipVersionFilter;
+    private final Class<?> expectedClass;
+
+    public SocketWithIpFilterTest(final int port, final IPVersionFilter ipVersionFilter, final Class<?> expectedClass) {
+        this.port = port;
+        this.ipVersionFilter = ipVersionFilter;
+        this.expectedClass = expectedClass;
+    }
+
+    @Parameterized.Parameters(name = "{index}: port={0}, filter={1} => expectedClass={2}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {httpPort, IPVersionFilter.IPV4, Inet4Address.class},
+                {httpPort, IPVersionFilter.IPV6, Inet6Address.class},
+                {httpPort, IPVersionFilter.IPV4_AND_IPV6, InetAddress.class},
+                {httpsPort, IPVersionFilter.IPV4, Inet4Address.class},
+                {httpsPort, IPVersionFilter.IPV6, Inet6Address.class},
+                {httpsPort, IPVersionFilter.IPV4_AND_IPV6, InetAddress.class}
+        });
+    }
+
+    @Test
+    public void testCreateSocket_WithIpFilter() throws Exception {
+        try (final ServerSocket server = new ServerSocket(port)) {
+            final URI uri = new URI("https://localhost:" + port);
+            final Socket socket = new SocketFactory().createSocket(uri, ipVersionFilter);
+
+            assertNotNull(socket);
+            assertTrue(socket.isConnected());
+            assertEquals("localhost", socket.getInetAddress().getHostName());
+            assertTrue(expectedClass.isInstance(socket.getInetAddress()));
+            assertEquals(port, socket.getPort());
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/socket/SocketWithIpFilterTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/socket/SocketWithIpFilterTest.java
@@ -49,7 +49,7 @@ public class SocketWithIpFilterTest {
     @Test
     public void testCreateSocket_WithIpFilter() throws Exception {
         try (final ServerSocket server = new ServerSocket(port)) {
-            final URI uri = new URI("https://localhost:" + port);
+            final URI uri = new URI("http" + (port == httpPort ? "" : "s") + "://localhost:" + port);
             final Socket socket = new SocketFactory().createSocket(uri, ipVersionFilter);
 
             assertNotNull(socket);

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -16,7 +16,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="WARN">
+        <Root level="INFO">
             <AppenderRef ref="ConsoleAppender"/>
             <AppenderRef ref="RollingFile"/>
         </Root>


### PR DESCRIPTION
*Issue #, if available:*

## 1. Dual-stack endpoints support

- Added support for dual-stack endpoints (.api.aws) for the prod endpoints and china endpoints.
- Implemented a new configuration option to toggle between legacy and dual-stack endpoints. (default: legacy)
- Added new builder parameter to `KinesisVideoClientConfiguration` and new constructor for `KinesisVideoJavaClientFactory` to accept this new parameter.

## 2. IP Filtering

- Introduced IPVersionFilter to allow forcing IPv4 or IPv6 connections. (default: no filter)
- Updated network-related classes (JavaKinesisVideoServiceClient & PutMediaClient) to respect the IP version filter setting. 
  - Pass custom DnsResolver to AWS SDK's
  - Use HttpRoutePlanner for ApacheHttpAsyncClient
  - Create a socket using the resolved IP address in ParallelSimpleHttpClient
- Added new builder parameter to `KinesisVideoClientConfiguration` and new constructor for `KinesisVideoJavaClientFactory` to accept this new parameter. 

## 3. Platform Testing Enhancements

- Introduce a new action to build the JNI for a specified git branch or tag
- Build the JNI on a separate machine to verify libraries can be moved to different targets. Utilize the [GitHub actions artifact system](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) for this.
- Added support for the M1 Apple Silicon macs in the matrix.
- Use DRY for the matrix - use `yq` and `jq` to make sure we only need to define the matrix once across the 3 different job definitions.
- Use the cross multiply to get the different combinations of platforms.
  - Run the unit tests on the different platforms
  - Run DemoAppMain and DemoAppCachedInfo on the different platforms

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/fc2fdf3e-853b-47a3-b3a0-9aa3d32c6bab" />

## 4. Sample Application Configurability and Proper Cleanup 

- Added `prepareStream.sh` script, which users can run before running the sample applications. This will make sure that the stream exists and has retention, and fix both issues if necessary. Some of the samples require pre-provisioned streams and won't run if the stream doesn't exist.
- Made the **stream name** and **streaming duration** configurable through JVM property for easier runs in the CI.
- Add cleanup logic to `DemoAppMain` after the streaming duration ends (free the mediasource and producer client). Discovered an issue with the cleanup with free producer call: https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/pull/1239, which is why the CI is currently set to run against the `develop` branch's JNI.
  - Verify the adjusted cleanup logic locally on my Mac and through CI, no more segfaults observed or NullPointerException.

## 5. Tests enhancements

- Added ability to append a prefix to the stream names used in the tests, allowing multiple instances of the tests to be run in parallel. (The tests fail when it gets rate limited)
  - Adjust assertions to account for the prefix
- Some of the tests require pre-provisioned streams. Implemented a new method `prepareStream()` to provision and verify the stream.
- The tests require the pre-provisioned streams to have data retention. In `prepareStream()`, it will check if the retention is 0 and increase it.
- Add proper checks for the JNI and a helpful error message if it couldn't be loaded.
- Add unit tests for more classes.

## 6. Misc

- In `HostnameVerifyingX509ExtendedTrustManager`, added ability to skip IP-based hostname verification when we know it will fail to avoid unnecessary debug logs and focus on the more relevant hostname-based verification (as per the name of the class...).
- Added javadoc to SocketFactory
- Added logs to some places
- Added toString method for KinesisVideoClientConfiguration

-----

*What was changed?*
- See the above

*Why was it changed?*
- See the above

*How was it changed?*
- See the above

*What testing was done for the changes?*
- Manual testing
- CI (see above)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
