### PR TITLE
Adding code coverage & report generation

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,51 @@
+name: Code coverage report
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  code-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'adopt'
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run tests
+        run: |
+          mvn clean verify -DargLine="\
+            -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} \
+            -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} \
+            -Daws.sessionToken=${AWS_SESSION_TOKEN} \
+            -Djava.library.path=src/main/resources/lib/ubuntu/ \
+            -Dlog4j.configurationFile=log4j2.xml"
+        shell: bash
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/site/jacoco/jacoco.xml
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ## Amazon Kinesis Video Streams Producer SDK Java
+<p align="center">
+  <a href="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/actions/workflows/ci.yml"> <img src="https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/actions/workflows/ci.yml/badge.svg"> </a>
+</p>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ $ java -classpath target/amazon-kinesis-video-streams-producer-sdk-java-1.12.1-j
 $ mvn clean test -DargLine="-Daws.accessKeyId=<YourAwsAccessKey> -Daws.secretKey=<YourAwsSecretKey> -Daws.sessionToken=<YourAwsSessionToken> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml"
 ```
 
+##### Generate code coverage report
+
+```shell
+mvn clean verify -DargLine="-Daws.accessKeyId=<YourAwsAccessKey> -Daws.secretKey=<YourAwsSecretKey> -Daws.sessionToken=<YourAwsSessionToken> -Djava.library.path=<NativeLibraryPath> -Dlog4j.configurationFile=log4j2.xml"
+```
+
+This will run the tests and generate a code coverage report. It will get output in `target/site/jacoco`. You can open `target/site/jacoco/index.html` in a web browser of your choice. 
+
 ##### Run the demo application from Docker
 
 Refer the **README.md** file in the  *dockerscripts* folder for running the build and demo app within Docker container.

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <argLine/>
     </properties>
 
     <groupId>com.amazonaws</groupId>
@@ -220,6 +221,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <!-- ${argLine} refers to the -DargLine JVM argument and @{argLine} is set by jacoco -->
+                    <argLine>@{argLine} ${argLine}</argLine>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.11</version>
-                <configuration>
-                    <destFile>${project.build.directory}/site/jacoco/jacoco.xml</destFile>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -234,6 +239,9 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -249,4 +257,3 @@
         </resources>
     </build>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,11 @@
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.11</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -212,12 +216,26 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
                 <configuration>
-                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                    <destFile>${project.build.directory}/site/jacoco/jacoco.xml</destFile>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
*Issue #, if available:*
- #188

*Description of changes:*
- #188 but rebased to the latest and additional features

Additional enhancements over the original:

1. Added HTML generation.
2. Instructions for generating a code coverage report:
```
mvn clean verify <args>
```

3. Fixed the `java.library.path` in the CI
4. Make it compatible with the maven surefire plugin. The original PR did not generate a report when `-DargLine` was specified.
5. Cleanup commented code, make it ready for merging

Notes:

* When you run mvn test, it will use sureFire plugin to find the tests
* -DargLine gets passed to surefire due to the fork implementation
* Jacoco sets argLine itself as part of the verify phase.
* So in the original PR, argLine gets overwritten by surefire and jacoco doesn't get triggered. When run independently, they don't overwrite each other.
* To fix this, we merge the two argLines together.

Testing:

Ran `mvn clean verify <...>` (with and without -DargLine) locally to check the generated site.

<img width="456" alt="image" src="https://github.com/user-attachments/assets/3eb43d41-f8ed-4d59-add2-e63b573e3fe8" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
