### PR TITLE
Capture RSS and CPU usage for the samples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,16 +186,24 @@ jobs:
           distribution: 'adopt'
           cache: maven
 
+      - name: Set up Python 3.12
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        working-directory: scripts/python
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Download JNI Library
         uses: actions/download-artifact@v4
         with:
           name: jni-library-${{ matrix.platform.name }}
           path: jni/
-
-      - name: Install dependencies (MacOS)
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew install coreutils # For `gtimeout`
 
       - name: Build with Maven
         run: mvn clean compile assembly:single
@@ -206,7 +214,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Create the stream (DemoAppCachedInfo)
+      - name: Create the stream (DemoAppMain)
         # This sample needs a pre-created stream: `${NAME}`
         if: ${{ matrix.sample == 'DemoAppMain' }}
         working-directory: scripts
@@ -238,24 +246,35 @@ jobs:
           fi
 
           echo "Using JAR file: $JAR_FILE"
-
-          # Use gtimeout on macOS and timeout on Linux
-          if [ "${{ runner.os }}" == "macOS" ]; then
-            TIMEOUT_CMD="gtimeout"
-          else
-            TIMEOUT_CMD="timeout"
-          fi
-
-          $TIMEOUT_CMD 30s java -classpath "$JAR_FILE" \
+          java -classpath "$JAR_FILE" \
             -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} \
             -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} \
             -Daws.sessionToken=${AWS_SESSION_TOKEN} \
             -Djava.library.path=${JNI_FOLDER} \
             -Dkvs-stream=$STREAM_NAME \
             -Dlog4j.configurationFile=log4j2.xml \
-            com.amazonaws.kinesisvideo.demoapp.${{ matrix.sample }}
+            com.amazonaws.kinesisvideo.demoapp.${{ matrix.sample }} &
+          JAVA_PID=$!
 
+          python ./scripts/python/capture_rss_and_cpu.py $JAVA_PID &
+          MONITOR_PID=$!
+
+          # Wait for maximum 30 seconds
+          TIMEOUT=30
+          for ((i=1; i<=TIMEOUT; i++)); do
+            if ! kill -0 $JAVA_PID 2>/dev/null; then
+              break
+            fi
+            sleep 1
+            if [ $i -eq $TIMEOUT ]; then
+              # Time's up, kill the process
+              kill -9 $JAVA_PID
+            fi
+          done
+
+          wait $JAVA_PID
           EXIT_CODE=$?
+          wait $MONITOR_PID
 
           set -e
 
@@ -299,3 +318,22 @@ jobs:
 
           echo Process exited with code: %EXIT_CODE%
           exit /b %EXIT_CODE%
+
+      - name: Generate memory and CPU graph (Mac and Linux)
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        run: |
+          DATA_FILE=$(find . -name 'process_*.txt' | head -n 1)
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          python ./scripts/python/plot_rss_and_cpu.py "$DATA_FILE" \
+            --title "Memory and CPU Usage (${{ matrix.sample }} @ ${COMMIT_HASH})\n${{ matrix.platform.os }}, Java ${{ matrix.java }}" \
+            --output "${{ env.STREAM_NAME }}-mem-cpu.png"
+
+        shell: bash
+
+      - name: Upload memory and CPU graph (Mac and Linux)
+        if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.STREAM_NAME }}-mem-cpu.png
+          path: ${{ env.STREAM_NAME }}-mem-cpu.png
+          retention-days: 7

--- a/scripts/python/capture_rss_and_cpu.py
+++ b/scripts/python/capture_rss_and_cpu.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+"""
+Process Monitor Script
+
+This script monitors CPU and RAM usage of a specified process using its PID.
+Metrics are recorded to a CSV file until the process terminates.
+"""
+
+import argparse
+import csv
+import os
+import sys
+import time
+
+from datetime import datetime
+from psutil import Process, NoSuchProcess, pid_exists
+
+
+class ProcessMonitor:
+    """Class to monitor process metrics including CPU and RAM usage."""
+
+    def __init__(self, pid: int, interval: float = 0.1):
+        """
+        Initialize the ProcessMonitor.
+
+        Args:
+            pid (int): Process ID to monitor
+            interval (float): Sampling interval in seconds
+        """
+        self.pid = pid
+        self.interval = interval
+        self.output_file = f'process_{pid}_metrics.txt'
+
+    def get_process_metrics(self) -> tuple[str, float, float] | None:
+        """
+        Collect current process metrics.
+
+        Returns:
+            tuple: (timestamp, memory_mb, cpu_percent) or None if process not found
+        """
+        try:
+            process = Process(self.pid)
+            cpu_percent = process.cpu_percent(interval=0.1)
+            memory_kb = process.memory_info().rss / 1024
+            timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+            return timestamp, memory_kb, cpu_percent
+
+        except NoSuchProcess:
+            print(f"Process with PID {self.pid} no longer exists")
+            return None
+        except Exception as e:
+            print(f"Error: {e}")
+            return None
+
+    def write_to_csv(self, data: tuple[str, float, float]) -> None:
+        """
+        Write metrics to CSV file.
+
+        Args:
+            data (tuple): (timestamp, memory_kb, cpu_percent)
+        """
+        file_exists = os.path.isfile(self.output_file)
+
+        with open(self.output_file, 'a', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+
+            if not file_exists:
+                writer.writerow(['Timestamp', 'RAM (KB)', 'CPU (%)'])
+
+            writer.writerow(data)
+
+    def record_metrics_until_process_ends(self) -> None:
+        """Start monitoring the process and recording metrics."""
+        print(f"Starting monitoring of PID {self.pid}")
+        print(f"Writing data to {self.output_file}")
+
+        try:
+            while True:
+                metrics = self.get_process_metrics()
+
+                if metrics is None:
+                    print("Process monitoring ended")
+                    break
+
+                self.write_to_csv(metrics)
+
+                time.sleep(self.interval)
+
+        except KeyboardInterrupt:
+            print("\nInterrupted by user")
+        except Exception as e:
+            print(f"Error: {e}")
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description='Monitor CPU and RAM usage of a process.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        'pid',
+        type=int,
+        help='Process ID to monitor'
+    )
+
+    parser.add_argument(
+        '-i', '--interval',
+        type=float,
+        default=0.1,
+        help='Sampling interval in seconds'
+    )
+
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    """
+    Checks the validity of arguments.
+
+    Raises an error if any of the args are invalid.
+    """
+    # Validate PID
+    if not pid_exists(args.pid):
+        raise ValueError(f"Error: Process with PID {args.pid} does not exist")
+
+    # Validate interval
+    if args.interval <= 0:
+        raise ValueError("Error: Interval must be greater than 0")
+
+
+def main() -> int:
+    """
+    Main function to run the process monitor.
+
+    Returns:
+        int: Exit code (0 for success, 1 for error)
+    """
+    try:
+        args = parse_arguments()
+
+        validate_args(args)
+
+        monitor = ProcessMonitor(args.pid, args.interval)
+        monitor.record_metrics_until_process_ends()
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/plot_rss_and_cpu.py
+++ b/scripts/python/plot_rss_and_cpu.py
@@ -1,0 +1,259 @@
+import argparse
+from datetime import timedelta
+import logging
+import os
+from typing import List, Tuple, Optional
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import TABLEAU_COLORS
+import numpy as np
+
+
+blue_color = TABLEAU_COLORS['tab:blue']
+orange_color = TABLEAU_COLORS['tab:orange']
+green_color = TABLEAU_COLORS['tab:green']
+
+SECONDS_PER_DAY = 86400
+
+logger = logging.getLogger(__name__)
+
+
+def parse_rss_file(file_path: str) -> Tuple[np.array, np.array, np.array]:
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    times = []
+    rss_values = []
+    cpu_values = []
+    start_time = None
+
+    with open(file_path, 'r', encoding='utf-8') as file:
+        for line in file:
+            try:
+                # Skip the header line: 'Timestamp,RAM (KB),CPU (%)'
+                if 'Timestamp' in line:
+                    continue
+
+                timestamp_str, rss_str, cpu_str = line.split(',')
+
+                # If the timestamp starts with a date (e.g. '2025-05-19 20:21:24.420'), chop it off
+                if ' ' in timestamp_str:
+                    timestamp_str = timestamp_str.split(' ')[1]
+
+                h, m, s = map(float, timestamp_str.split(':'))
+                current_time = timedelta(hours=h, minutes=m, seconds=s)
+
+                if start_time is None:
+                    start_time = current_time
+
+                elapsed_time = (current_time - start_time).total_seconds()
+
+                # To handle the case that it rolls over midnight
+                if elapsed_time < 0:
+                    elapsed_time += SECONDS_PER_DAY
+
+                rss_value = float(rss_str)
+                cpu_value = float(cpu_str)
+
+                times.append(elapsed_time)
+                rss_values.append(rss_value)
+                cpu_values.append(cpu_value)
+            except Exception as e:
+                logger.error(f"Error parsing line in {file_path}: {line}. Error: {e}")
+
+    if len(times) == 0 or len(rss_values) == 0:
+        raise ValueError(f'The file {file_path} is bad or corrupted!')
+
+    return np.asarray(times), np.asarray(rss_values), np.asarray(cpu_values)
+
+
+def convert_memory_units(memory_values: np.ndarray) -> Tuple[np.ndarray, str]:
+    """
+    Convert memory values to appropriate units (KiB, MiB, or GiB).
+
+    Args:
+        memory_values: Array of memory values in KiB
+
+    Returns:
+        Tuple of (converted values, unit string)
+    """
+    max_value = np.max(memory_values)
+
+    if max_value > 1024 * 1024:  # More than 1 GiB
+        return memory_values / (1024 * 1024), 'GiB'
+    elif max_value > 1024:  # More than 1 MiB
+        return memory_values / 1024, 'MiB'
+    else:
+        return memory_values, 'KiB'
+
+
+def plot_rss_and_cpu(data_set: Tuple[np.ndarray, np.ndarray, np.ndarray, str],
+                     key_points: Optional[List[Tuple[float, str]]] = None,
+                     save_path: Optional[str] = None,
+                     title: Optional[str] = None,
+                     x_max: Optional[float] = None,
+                     y_min: Optional[float] = None,
+                     y_max: Optional[float] = None) -> None:
+    """
+    Plot RSS and CPU usage over time.
+
+    Args:
+        data_set: Tuple containing (times, rss_values, cpu_values, label)
+        key_points: List of tuples containing (time, label) for marking points
+        save_path: Path to save the plot
+        title: Title of the plot
+        x_max: Maximum value for x-axis
+        y_min: Minimum value for y-axis
+        y_max: Maximum value for y-axis
+    """
+    fig, ax1 = plt.subplots(figsize=(12, 6))
+    ax2 = ax1.twinx()
+
+    alpha = 0.5
+    marker = None
+
+    times, rss_values, cpu_values, label = data_set
+
+    converted_rss, rss_unit = convert_memory_units(rss_values)
+
+    if x_max is not None:
+        # Truncate data beyond the maximum x-value
+        within_x_max = times <= x_max
+        times = times[within_x_max]
+        rss_values = rss_values[within_x_max]
+
+    # Plot RSS on left y-axis
+    plot_label = f'{label} RSS'
+    ax1.plot(times, converted_rss,
+             marker=marker, linestyle='-', color=blue_color, alpha=alpha, label=plot_label)
+
+    # Plot CPU on right y-axis
+    cpu_label = f'{label} CPU%'
+    ax2.plot(times, cpu_values,
+             marker=marker, linestyle='--', color=orange_color, alpha=alpha, label=cpu_label)
+
+    plt.title(title.replace('\\n', '\n'), fontsize='x-large')
+    ax1.set_xlabel('Time (seconds since start)', fontsize='large')
+    ax1.set_ylabel(f'RSS ({rss_unit})', fontsize='large', color=blue_color)
+    ax2.set_ylabel('CPU %', fontsize='large', color=orange_color)
+
+    # Set grid
+    ax1.grid(True)
+
+    # Set x-axis limits
+    ax1.set_xlim(left=0)
+    if x_max is not None:
+        ax1.set_xlim(right=x_max)
+
+    # Set y-axis limits if provided
+    if y_min is not None:
+        ax1.ylim(bottom=y_min)
+    if y_max is not None:
+        ax1.ylim(top=y_max)
+
+    if key_points:
+        min_rss = np.min(rss_values)
+        max_rss = np.max(rss_values)
+        y_range = max_rss - min_rss
+        for time, label in key_points:
+            ax1.axvline(x=time, color=green_color, linestyle=':')
+
+            # Find the nearest data point in the first dataset for positioning
+            nearest_index = np.argmin(np.abs(data_set[0] - time))
+            nearest_value = data_set[1][nearest_index]
+
+            # Determine best label position
+            label_positions = [
+                (max_rss - 0.1 * y_range, 'center_baseline'),  # Near top
+                (min_rss + 0.1 * y_range, 'baseline'),  # Near bottom
+                (nearest_value + 0.1 * y_range, 'baseline'),  # Above nearest point
+                (nearest_value - 0.1 * y_range, 'baseline')  # Below nearest point
+            ]
+
+            if y_min is not None:
+                # Just above y-min
+                label_positions.append((y_min + 0.1 * y_range, 'baseline'))
+
+            if y_max is not None:
+                # Just below y-max
+                label_positions.append((y_max - 0.1 * y_range, 'center_baseline'))
+
+            # Choose the position furthest from the nearest data point
+            label_y, vertical_alignment = max(label_positions,
+                                              key=lambda y: abs(y[0] - nearest_value))
+
+            ax1.text(time, label_y, label,
+                     rotation=90,
+                     verticalalignment=vertical_alignment,
+                     horizontalalignment='center',
+                     bbox={"facecolor": 'white', "alpha": 0.7, "edgecolor": 'none'})
+
+    plt.gca().xaxis.set_major_formatter(
+        plt.FuncFormatter(
+            lambda x, _: str(timedelta(seconds=int(x)))
+        )
+    )
+
+    plt.subplots_adjust(bottom=0.2)  # Adding space for the legend
+    lgd1 = ax1.legend(loc='upper center', bbox_to_anchor=(0.3, -0.15))
+    lgd2 = ax2.legend(loc='upper center', bbox_to_anchor=(0.7, -0.15))
+
+    if save_path:
+        plt.savefig(save_path, bbox_extra_artists=(lgd1, lgd2), bbox_inches='tight')
+        logger.info(f"Plot saved to {save_path}")
+    else:
+        plt.show()
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(filename)s:%(lineno)s/%(funcName)-s()] [%(levelname)s] %(message)s',
+        handlers=[
+            logging.StreamHandler()  # Outputs logs to the console
+        ]
+    )
+
+    parser = argparse.ArgumentParser(description='Plot RSS memory usage over time.')
+    parser.add_argument('data_file', help='Input file')
+    parser.add_argument('--output', '-o',
+                        help='Path to save the output plot (default: None, '
+                             'example: rss_memory_usage_plot.png)')
+    parser.add_argument('--title', '-t', default='RSS and CPU Memory Usage Over Time',
+                        help='Title for the graph (default: "Memory and CPU Usage Over Time")')
+    parser.add_argument('--key-points', '-k', nargs=2, action='append',
+                        metavar=('TIME', 'LABEL'),
+                        help='Key points (in seconds) to mark with vertical labels. '
+                             'Can be used multiple times.')
+    parser.add_argument('--y-min',
+                        type=int, help='Minimum value for y-axis')
+    parser.add_argument('--y-max',
+                        type=int, help='Maximum value for y-axis')
+    parser.add_argument('--x-max',
+                        type=int, help='Maximum value for x-axis (seconds).')
+
+    parser.add_argument('--same-color', action='store_true',
+                        help='Plot all files with the same color and lower '
+                             'opacity with a single legend label')
+
+    args = parser.parse_args()
+
+    key_points = []
+    if args.key_points:
+        for time, label in args.key_points:
+            key_points.append((float(time), label))
+
+    times, rss_values, cpu_values = parse_rss_file(args.data_file)
+    data_set = (times, rss_values, cpu_values, args.data_file)
+
+    plot_rss_and_cpu(data_set=data_set,
+                     key_points=key_points,
+                     save_path=args.output,
+                     title=args.title,
+                     x_max=args.x_max,
+                     y_min=args.y_min,
+                     y_max=args.y_max)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -1,0 +1,12 @@
+contourpy==1.3.2
+cycler==0.12.1
+fonttools==4.58.0
+kiwisolver==1.4.8
+matplotlib==3.10.3
+numpy==2.2.6
+packaging==25.0
+pillow==11.2.1
+psutil==7.0.0
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+six==1.17.0


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Measure the RSS and CPU usage of the sample applications
- We can view them in the actions summary screen. 

<details><summary>Where to find it</summary>

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/afeef744-aa14-4115-860a-0374436b8a60" />

</details>

- Note: Even though GitHub supports markdown summaries, it doesn't support embedding 'temporary' images into it. So unfortunately we have to download the images each time (unless we push all the images to a branch or host it elsewhere).

*Why was it changed?*
- Automate collection of the memory usage and CPU usage for every PR.

*How was it changed?*
- The python script uses [psutil](https://pypi.org/project/psutil/) to capture the RSS (bytes). We use this one instead of `ps` utility because the `ps` is platform-dependent.
- We use matplotlib to plot the data and upload it.

*What testing was done for the changes?*
- Ran this on my fork and it generated the following graphs. From the few runs I did, it seems fairly consistent.
- ~140 MiB of RAM consumed and fairly low CPU usage after the initial startup.

<details><summary>Generated graphs</summary>

![producer-java-ubuntu-22 04-java-11_DemoAppMain-mem-cpu](https://github.com/user-attachments/assets/abac6a38-67fb-48d1-b543-cda1797c7098)

![producer-java-ubuntu-22 04-java-11_DemoAppCachedInfo-mem-cpu](https://github.com/user-attachments/assets/00676e27-a415-4d35-87be-bdd41d4a627b)

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
