### PR TITLE
Adjust PR template and make code coverage job only run in this repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,16 @@
 *Issue #, if available:*
+- N/A
 
 *What was changed?*
+- 
 
 *Why was it changed?*
+- 
 
 *How was it changed?*
+- 
 
 *What testing was done for the changes?*
+- 
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   code-coverage:
+    if: ${{ github.repository == 'awslabs/amazon-kinesis-video-streams-producer-sdk-java' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add bullet points to the PR template
- Don't run the code coverage job in forks by default.

*Why was it changed?*
- Less keyboard inputs needed to make a PR description.
- The code coverage job requires a codecov token, which most forks don't have setup.

*How was it changed?*
- Adjust the PR template to have the empty bullet points (markdown)
- Add a condition to the codecov job definition yaml

*What testing was done for the changes?*
- Run the CI for these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
