### PR TITLE
Make the frame timecodes consistent

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFileMediaSourceConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFileMediaSourceConfiguration.java
@@ -3,6 +3,7 @@ package com.amazonaws.kinesisvideo.java.mediasource.file;
 
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceConfiguration;
 
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.FRAME_DURATION_0_MS;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.VIDEO_CONTENT_TYPE;
 
 public class ImageFileMediaSourceConfiguration implements MediaSourceConfiguration {
@@ -14,6 +15,7 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
     private final int endFileIndex;
     private final String contentType;
     private final boolean allowStreamCreation;
+    private final long startTimeMs;
 
     public ImageFileMediaSourceConfiguration(final Builder builder) {
         this.fps = builder.fps;
@@ -23,6 +25,7 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         this.endFileIndex = builder.endFileIndex;
         this.contentType = builder.contentType;
         this.allowStreamCreation = builder.allowStreamCreation;
+        this.startTimeMs = builder.startTimeMs;
     }
 
     public int getFps() {
@@ -49,6 +52,8 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         return contentType;
     }
 
+    public long getStartTimeMs() { return startTimeMs; }
+
     @Override
     public String getMediaSourceType() {
         return null;
@@ -72,6 +77,7 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         private int endFileIndex;
         private String contentType = VIDEO_CONTENT_TYPE;
         private boolean allowStreamCreation;
+        private long startTimeMs = System.currentTimeMillis();
 
         public Builder fps(final int fps) {
             this.fps = fps;
@@ -108,6 +114,11 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
 
         public Builder allowStreamCreation(final Boolean allowStreamCreation) {
             this.allowStreamCreation = allowStreamCreation;
+            return this;
+        }
+
+        public Builder startTimeMs(final long startTimeMs) {
+            this.startTimeMs = startTimeMs;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
@@ -40,11 +40,13 @@ public class ImageFrameSource {
     private final Log log = LogFactory.getLog(ImageFrameSource.class);
     private final String metadataName = "ImageLoop";
     private int metadataCount = 0;
+    private long currentFrameTimestampMs;
 
     public ImageFrameSource(final ImageFileMediaSourceConfiguration configuration) {
         this.configuration = configuration;
         this.totalFiles = getTotalFiles(configuration.getStartFileIndex(), configuration.getEndFileIndex());
         this.fps = configuration.getFps();
+        this.currentFrameTimestampMs = configuration.getStartTimeMs();
     }
 
     private int getTotalFiles(final int startIndex, final int endIndex) {
@@ -84,9 +86,10 @@ public class ImageFrameSource {
     }
 
     private void generateFrameAndNotifyListener() throws KinesisVideoException {
+        final long frameDuration = Duration.ofSeconds(1L).toMillis() / fps;
         while (isRunning) {
             if (mkvDataAvailableCallback != null) {
-                mkvDataAvailableCallback.onFrameDataAvailable(createKinesisVideoFrameFromImage(frameCounter));
+                mkvDataAvailableCallback.onFrameDataAvailable(createKinesisVideoFrameFromImage(frameCounter, currentFrameTimestampMs));
                 if (isMetadataReady()) {
                     mkvDataAvailableCallback.onFragmentMetadataAvailable(metadataName + metadataCount,
                             Integer.toString(metadataCount++), false);
@@ -94,8 +97,9 @@ public class ImageFrameSource {
             }
 
             frameCounter++;
+            currentFrameTimestampMs += frameDuration;
             try {
-                Thread.sleep(Duration.ofSeconds(1L).toMillis() / fps);
+                Thread.sleep(frameDuration);
             } catch (final InterruptedException e) {
                 log.error("Frame interval wait interrupted by Exception ", e);
             }
@@ -106,12 +110,11 @@ public class ImageFrameSource {
         return frameCounter % METADATA_INTERVAL == 0;
     }
 
-    private KinesisVideoFrame createKinesisVideoFrameFromImage(final long index) {
+    private KinesisVideoFrame createKinesisVideoFrameFromImage(final long index, final long timestampMs) {
         final String filename = String.format(
                 configuration.getFilenameFormat(),
                 index % totalFiles + configuration.getStartFileIndex());
         final Path path = Paths.get(configuration.getDir() + filename);
-        final long currentTimeMs = System.currentTimeMillis();
 
         final int flags = isKeyFrame() ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
@@ -120,8 +123,8 @@ public class ImageFrameSource {
             return new KinesisVideoFrame(
                     frameCounter,
                     flags,
-                    currentTimeMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                    currentTimeMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    timestampMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    timestampMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
                     FRAME_DURATION_20_MS * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
                     ByteBuffer.wrap(data));
         } catch (final IOException e) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Making the frame timecodes consistently spaced for the ImageFileMediaSource

*Why was it changed?*
- When querying the persisted fragments, the fragment timecodes are not consistently spaced

Before:

Attempt 1:

|   FragmentNumber |   Size (B) | Producer Time   | Server Time   |   Length (ms) |
|----------|------------|-----------------|---------------|---------------|
|     1 |      58985 | 23:59:15.179    | 23:59:15.558  |          1056 |
|    2  |      60282 | 23:59:16.280    | 23:59:16.373  |          1073 |

Attempt 2:

|   FragmentNumber |   Size (B) | Producer Time   | Server Time   |   Length (ms) |
|----------|------------|-----------------|---------------|---------------|
| 1 |      58985 | 00:06:00.515    | 00:06:00.885  |          1088 |
| 2 |      60282 | 00:06:01.649    | 00:06:01.748  |          1072 |

After:

|   FragmentNumber |   Size (B) | Producer Time   | Server Time   |   Length (ms) |
|----------|------------|-----------------|---------------|---------------|
| 1 |      58985 | 10:30:52.830    | 10:30:53.237  |           960 |
| 2 |      60282 | 10:30:53.830    | 10:30:54.055  |           960 |

*How was it changed?*
- Instead of using the `getCurrentTime()` function to determine the timestamp, we instead increment the timestamp by the frame's duration. (Frame duration = 1 / FPS)

*What testing was done for the changes?*
- Manually checked that the fragment duration is showing consistent numbers. The frames for the `DemoAppMain` are as follows:

|   FragmentNumber |   Size (B) | Producer Time   | Server Time   |   Length (ms) |
|----------|------------|-----------------|---------------|---------------|
| 1 |      58985 | 10:30:52.830    | 10:30:53.237  |           960 |
| 2 |      60282 | 10:30:53.830    | 10:30:54.055  |           960 |
| 3 |      69937 | 10:30:54.830    | 10:30:55.215  |           960 |
| 4 |      58985 | 10:31:07.127    | 10:31:07.377  |           960 |
| 5 |      60282 | 10:31:08.127    | 10:31:08.334  |           960 |
| 6 |      69937 | 10:31:09.127    | 10:31:09.484  |           960 |
| 7 |      72840 | 10:31:10.127    | 10:31:10.645  |           960 |
| 8 |      75667 | 10:31:11.127    | 10:31:11.800  |           960 |
| 9 |      73376 | 10:31:12.127    | 10:31:12.979  |           960 |
| 10 |      65788 | 10:31:13.127    | 10:31:14.149  |           960 |
| 11 |      69833 | 10:31:14.127    | 10:31:15.323  |           960 |
| 12 |      58985 | 12:41:07.238    | 12:41:07.448  |           960 |
| 13 |      60282 | 12:41:08.238    | 12:41:08.380  |           960 |
| 14 |      69937 | 12:41:09.238    | 12:41:09.514  |           960 |
| 15 |      72840 | 12:41:10.238    | 12:41:10.685  |           960 |
| 16 |      75667 | 12:41:11.238    | 12:41:11.783  |           960 |
| 17 |      73376 | 12:41:12.238    | 12:41:12.909  |           960 |
| 18 |      65788 | 12:41:13.238    | 12:41:14.034  |           960 |
| 19 |      69833 | 12:41:14.238    | 12:41:15.179  |           960 |
| 20 |      61020 | 12:41:15.238    | 12:41:16.314  |           840 |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
