### PR TITLE
Fix ImageFrameSource Shutdown Sequence

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
@@ -15,9 +15,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_KEY_FRAME;
 import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_NONE;
@@ -37,13 +39,13 @@ public class ImageFrameSource {
 
     private final int totalFiles;
     private OnStreamDataAvailable mkvDataAvailableCallback;
-    private boolean isRunning = false;
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private int frameCounter;
     private final Log log = LogFactory.getLog(ImageFrameSource.class);
     private final String metadataName = "ImageLoop";
     private int metadataCount = 0;
     private long currentFrameTimestampMs;
-    private long executorShutdownTimeoutSeconds = 5L;
+    private final long executorShutdownTimeoutSeconds = 5L;
 
     public ImageFrameSource(final ImageFileMediaSourceConfiguration configuration) {
         this.configuration = configuration;
@@ -58,16 +60,16 @@ public class ImageFrameSource {
     }
 
     public void start() {
-        if (isRunning) {
+        if (isRunning.get()) {
             throw new IllegalStateException("Frame source is already running");
         }
 
-        isRunning = true;
+        isRunning.set(true);
         startFrameGenerator();
     }
 
     public void stop() {
-        isRunning = false;
+        isRunning.set(false);
         stopFrameGenerator();
     }
 
@@ -92,7 +94,7 @@ public class ImageFrameSource {
         final double frameDurationMs = (double) Duration.ofSeconds(1L).toMillis() / fps;
         long nextFrameTimeNs = System.nanoTime(); // to prevent time drift
 
-        while (isRunning) {
+        while (isRunning.get()) {
             if (mkvDataAvailableCallback != null) {
                 mkvDataAvailableCallback.onFrameDataAvailable(createKinesisVideoFrameFromImage(frameCounter, currentFrameTimestampMs));
                 if (isMetadataReady()) {
@@ -153,10 +155,20 @@ public class ImageFrameSource {
         executor.shutdown();
         try {
             if (!executor.awaitTermination(this.executorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
+                log.warn("Executor did not terminate in time. Forcing shutdown.");
+                final List<Runnable> droppedTasks = executor.shutdownNow();
+                log.warn("Number of dropped tasks: " + droppedTasks.size());
+                for (final Runnable task : droppedTasks) {
+                    log.warn("Dropped task of type: " + task.getClass().getName());
+                }
             }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
+        } catch (final InterruptedException e) {
+            log.error("Executor shutdown interrupted with Exception ", e);
+            final List<Runnable> droppedTasks = executor.shutdownNow();
+            log.warn("Number of dropped tasks: " + droppedTasks.size());
+            for (final Runnable task : droppedTasks) {
+                log.warn("Dropped task of type: " + task.getClass().getName());
+            }
             Thread.currentThread().interrupt();
         }
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_KEY_FRAME;
 import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_NONE;
@@ -42,6 +43,7 @@ public class ImageFrameSource {
     private final String metadataName = "ImageLoop";
     private int metadataCount = 0;
     private long currentFrameTimestampMs;
+    private long executorShutdownTimeoutSeconds = 5L;
 
     public ImageFrameSource(final ImageFileMediaSourceConfiguration configuration) {
         this.configuration = configuration;
@@ -149,5 +151,13 @@ public class ImageFrameSource {
 
     private void stopFrameGenerator() {
         executor.shutdown();
+        try {
+            if (!executor.awaitTermination(this.executorShutdownTimeoutSeconds, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
[internal]

*What was changed?*
When the DemoApp shuts down, there exists a possibility that the frame generator is still submitting frames after the KVS stream has been shutdown, leading to the following error: `0x52000052 | STATUS_STREAM_HAS_BEEN_STOPPED`.

The reason for this possibility is that the executor shutdown call for the frame generator task does no await for the shutdown before shutting down the KVS stream. This fix involves adding a wait and a timeout for the executor shutdown and adds a forced shutdownNow if the timeout has expired.

*Why was it changed?*
To fix the error sometimes seen when the demo app shuts down.

*How was it changed?*
By making the fix described above.

*What testing was done for the changes?*
The fix was tested using the following steps:
1. First validated the reported intermittent 0x52000052 issue by running the DemoApp in a shell loop and reducing the DemoApp runtime duration DEFAULT_DURATION_TO_STREAM to 4 seconds for faster iteration.
2. The error was observed within ~5 iterations.
3. Then applied the fix and let the loop to run 50+ iterations.
4. The error no longer occurs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
