### PR TITLE
Add tracking for some native stats

### DIFF
--- a/.github/matrix.yaml
+++ b/.github/matrix.yaml
@@ -13,3 +13,4 @@ matrix:
   sample:
     - DemoAppMain
     - DemoAppCachedInfo
+    - DemoAppMainWithHeapTracking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,9 +201,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Create the stream (DemoAppMain)
+      - name: Create the stream (DemoAppMain and DemoAppMainWithHeapTracking)
         # This sample needs a pre-created stream: `${NAME}`
-        if: ${{ matrix.sample == 'DemoAppMain' }}
+        if: ${{ matrix.sample == 'DemoAppMain' || matrix.sample == 'DemoAppMainWithHeapTracking' }}
         working-directory: scripts
         run: |
           ./prepareStream.sh "$STREAM_NAME"
@@ -311,9 +311,42 @@ jobs:
         run: |
           DATA_FILE=$(find . -name 'process_*.txt' | head -n 1)
           COMMIT_HASH=$(git rev-parse --short HEAD)
+          mkdir output
           python ./scripts/python/benchmarking/plot_rss_and_cpu.py "$DATA_FILE" \
             --title "Memory and CPU Usage (${{ matrix.sample }} @ ${COMMIT_HASH})\n${{ matrix.platform.os }}, Java ${{ matrix.java }}" \
-            --output "${{ env.STREAM_NAME }}-mem-cpu.png"
+            --output "output/${{ env.STREAM_NAME }}-mem-cpu.png"
+          
+          mv "$DATA_FILE" output
+        shell: bash
+
+      - name: Generate heap usage graphs (Mac and Linux) (DemoAppMainWithHeapTracking)
+        if: ${{ (runner.os == 'macOS' || runner.os == 'linux') && matrix.sample == 'DemoAppMainWithHeapTracking' }}
+        env:
+          DATA_FILE: memory-data.csv
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          python ./scripts/python/benchmarking/csv_plotter.py "$DATA_FILE" \
+            --x-column "Timestamp" \
+            --y-column "Malloc Usage (Bytes)" \
+            --x-label "Elapsed duration" \
+            --y-label "Malloc Usage" \
+            --convert-memory \
+            --title "Malloc usage over time (${{ matrix.sample }} @ ${COMMIT_HASH})" \
+            --zero-start \
+            --zero-end \
+            -o "output/malloc-usage.png"
+
+          python ./scripts/python/benchmarking/csv_plotter.py "$DATA_FILE" \
+            --x-column "Timestamp" \
+            --y-column "Content Store Used (Bytes out of 256000000)" \
+            --x-label "Elapsed duration" \
+            --y-label "Content store used" \
+            --convert-memory \
+            --title "Content store usage over time (${{ matrix.sample }} @ ${COMMIT_HASH})\n(Out of 244.14 MiB)" \
+            --zero-end \
+            -o "output/content-store-usage.png"
+
+          mv "$DATA_FILE" output
 
         shell: bash
 
@@ -345,6 +378,6 @@ jobs:
         if: ${{ runner.os == 'macOS' || runner.os == 'linux' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.STREAM_NAME }}-mem-cpu.png
-          path: ${{ env.STREAM_NAME }}-mem-cpu.png
+          name: ${{ env.STREAM_NAME }}-data
+          path: output/
           retention-days: 7

--- a/.github/workflows/codeql-scan.yml
+++ b/.github/workflows/codeql-scan.yml
@@ -24,10 +24,8 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: java-kotlin
-          build-mode: none
+          languages: java
+          build-mode: autobuild
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:java-kotlin"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs
 hs_err_pid*.log
 dependency/
 build/
+memory-data.csv

--- a/jni/com/amazonaws/kinesis/video/producer/jni/NativeProducerInterface.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/NativeProducerInterface.cpp
@@ -453,6 +453,17 @@ CleanUp:
         LEAVE();
     }
 
+    PUBLIC_API void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_setupInstrumentedAllocators(JNIEnv* env, jobject thiz)
+    {
+        ::setInstrumentedAllocators();
+    }
+
+    PUBLIC_API jlong JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_getCurrentAllocationBytes(JNIEnv* env, jobject thiz)
+    {
+        SIZE_T allocationSize = ::getInstrumentedTotalAllocationSize();
+        return allocationSize;
+    }
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/jni/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
+++ b/jni/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
@@ -206,9 +206,9 @@ JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_Nat
  * Class:     com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni
  * Method:    kinesisVideoStreamTerminated
  * Signature: (JJJI)V
-  */
- JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_kinesisVideoStreamTerminated
-   (JNIEnv *, jobject, jlong, jlong, jlong, jint);
+ */
+JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_kinesisVideoStreamTerminated
+  (JNIEnv *, jobject, jlong, jlong, jlong, jint);
 
 /*
  * Class:     com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni

--- a/jni/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
+++ b/jni/include/com/amazonaws/kinesis/video/producer/jni/com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni.h
@@ -206,9 +206,25 @@ JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_Nat
  * Class:     com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni
  * Method:    kinesisVideoStreamTerminated
  * Signature: (JJJI)V
+  */
+ JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_kinesisVideoStreamTerminated
+   (JNIEnv *, jobject, jlong, jlong, jlong, jint);
+
+/*
+ * Class:     com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni
+ * Method:    setupInstrumentedAllocators
+ * Signature: ()V
  */
-JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_kinesisVideoStreamTerminated
-(JNIEnv *, jobject, jlong, jlong, jlong, jint);
+JNIEXPORT void JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_setupInstrumentedAllocators
+  (JNIEnv* env, jobject);
+
+/*
+ * Class:     com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni
+ * Method:    getCurrentAllocationBytes
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_getCurrentAllocationBytes
+  (JNIEnv *, jobject);
 
 #ifdef __cplusplus
 }

--- a/scripts/python/benchmarking/csv_plotter.py
+++ b/scripts/python/benchmarking/csv_plotter.py
@@ -1,0 +1,303 @@
+import argparse
+import logging
+import os
+from typing import List, Tuple, Optional
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import TABLEAU_COLORS
+import numpy as np
+import pandas as pd
+
+blue_color = TABLEAU_COLORS['tab:blue']
+orange_color = TABLEAU_COLORS['tab:orange']
+green_color = TABLEAU_COLORS['tab:green']
+
+logger = logging.getLogger(__name__)
+
+
+def get_column_reference(df: pd.DataFrame, column_spec: str) -> str:
+    """
+    Convert a column specification (name or index) to a column name.
+
+    Args:
+        df: DataFrame containing the data
+        column_spec: Column specification (name or index)
+
+    Returns:
+        Column name
+    """
+    try:
+        # Try to convert to integer for index-based access
+        idx = int(column_spec)
+        if idx < 0 or idx >= len(df.columns):
+            raise ValueError(f"Column index {idx} is out of range [0, {len(df.columns) - 1}]")
+        return df.columns[idx]
+    except ValueError:
+        # If conversion fails, treat as column name
+        if column_spec not in df.columns:
+            raise ValueError(f"Column '{column_spec}' not found in CSV file. Available columns: {list(df.columns)}")
+        return column_spec
+
+
+def parse_csv_columns(file_path: str, x_column: str, y_column: str,
+                      zero_start: bool = False, zero_end: bool = False) -> Tuple[np.array, np.array]:
+    """
+    Parse specified columns from a CSV file.
+    If x_column contains timestamps, converts them to duration from first timestamp.
+
+    Args:
+        file_path: Path to the CSV file
+        x_column: Name of the column to use for x-axis
+        y_column: Name of the column to use for y-axis
+        zero_start: Whether to add a zero value at the start
+        zero_end: Whether to add a zero value at the end
+
+    Returns:
+        Tuple of (x_values, y_values)
+    """
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    df = pd.read_csv(file_path)
+
+    # Convert column specifications to actual column names
+    x_column = get_column_reference(df, x_column)
+    y_column = get_column_reference(df, y_column)
+
+    # Try to convert x_column to datetime if it contains timestamp data
+    # Note: We want to have durations instead of dates (e.g. 1 second in, 10 minutes in, etc...)
+    try:
+        timestamps = pd.to_datetime(df[x_column])
+        # Convert to duration in seconds from first timestamp
+        start_time = timestamps.iloc[0]
+        x_values = [(t - start_time).total_seconds() for t in timestamps]
+        x_values = np.array(x_values)
+
+    except (ValueError, TypeError):
+        # If conversion fails, use original values
+        x_values = np.array(df[x_column])
+
+    y_values = np.array(df[y_column])
+
+    # Calculate typical interval (use the first interval as reference)
+    if len(x_values) >= 2:
+        interval = x_values[1] - x_values[0]
+    else:
+        interval = 1.0  # fallback if only one point
+
+    if zero_start:
+        x_values = np.concatenate((x_values, [x_values[-1] + interval]))
+        y_values = np.concatenate(([0], y_values))
+
+    if zero_end:
+        x_values = np.concatenate((x_values, [x_values[-1] + interval]))
+        y_values = np.concatenate((y_values, [0]))
+
+    return x_values, y_values
+
+
+def convert_memory_units(memory_values: np.ndarray) -> Tuple[np.ndarray, str]:
+    """
+    Convert memory values to appropriate units (Bytes, KiB, MiB, or GiB).
+
+    Args:
+        memory_values: Array of memory values in bytes
+
+    Returns:
+        Tuple of (converted values, unit string)
+    """
+    max_value = np.max(memory_values)
+
+    if max_value > 1024 * 1024 * 1024:  # More than 1 GiB
+        return memory_values / (1024 * 1024 * 1024), 'GiB'
+    elif max_value > 1024 * 1024:  # More than 1 MiB
+        return memory_values / (1024 * 1024), 'MiB'
+    elif max_value > 1024:  # More than 1 KiB
+        return memory_values / 1024, 'KiB'
+    else:
+        return memory_values, 'Bytes'
+
+
+def plot_data(x_values: np.array,
+              y_values: np.array,
+              x_label: str,
+              y_label: str,
+              title: str,
+              save_path: Optional[str] = None,
+              key_points: Optional[List[Tuple[float, str]]] = None,
+              y_min: Optional[float] = None,
+              y_max: Optional[float] = None,
+              convert_memory: bool = False) -> None:
+    """
+    Plot data from CSV columns.
+
+    Args:
+        x_values: Values for x-axis
+        y_values: Values for y-axis
+        x_label: Label for x-axis
+        y_label: Label for y-axis
+        title: Plot title
+        save_path: Path to save the plot
+        key_points: List of tuples containing (x_value, label) for marking points
+        y_min: Minimum value for y-axis
+        y_max: Maximum value for y-axis
+        convert_memory: Whether to convert y-values to appropriate memory units
+    """
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    # Convert memory values if requested
+    if convert_memory:
+        y_values, unit = convert_memory_units(y_values)
+        y_label = f"{y_label} ({unit})"
+
+    # Plot data
+    ax.plot(x_values, y_values, color=blue_color)
+
+    ax.set_xlabel(x_label, fontsize='large')
+    ax.set_ylabel(y_label, fontsize='large')
+    plt.title(title.replace('\\n', '\n'), fontsize='x-large')
+
+    ax.grid(True)
+
+    # Set y-axis limits if provided
+    if y_min is not None:
+        ax.set_ylim(bottom=y_min)
+    if y_max is not None:
+        ax.set_ylim(top=y_max)
+
+    ax.set_xlim(left=0)
+
+    # Format x-axis labels as HH:MM:SS
+    def format_time(x, _):
+        hours = int(x // 3600)
+        minutes = int((x % 3600) // 60)
+        seconds = int(x % 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(format_time))
+
+    if key_points:
+        # Get the current y-axis limits
+        y_min_plot, y_max_plot = ax.get_ylim()
+        usable_range = y_max_plot - y_min_plot
+
+        for x_val, label in key_points:
+            ax.axvline(x=x_val, color=green_color, linestyle=':')
+
+            # Find all values within a small window around the vertical line
+            window = (max(x_values) - min(x_values)) * 0.02  # 2% of total range
+            window_indices = np.where(np.abs(x_values - x_val) <= window)[0]
+            window_values = y_values[window_indices]
+
+            # Define possible positions
+            positions = [
+                (y_min_plot + 0.15 * usable_range, 'bottom'),
+                (y_min_plot + 0.3 * usable_range, 'bottom'),
+                (y_min_plot + 0.5 * usable_range, 'center'),
+                (y_max_plot - 0.3 * usable_range, 'top'),
+                (y_max_plot - 0.15 * usable_range, 'top')
+            ]
+
+            # Find best position for label
+            best_position = None
+            max_min_distance = -float('inf')
+
+            for pos, alignment in positions:
+                distances = np.abs(window_values - pos)
+                min_distance = np.min(distances) if len(distances) > 0 else float('inf')
+
+                if min_distance > max_min_distance:
+                    max_min_distance = min_distance
+                    best_position = (pos, alignment)
+
+            label_y, vertical_alignment = best_position
+
+            ax.text(x_val, label_y, label,
+                    rotation=90,
+                    verticalalignment=vertical_alignment,
+                    horizontalalignment='center',
+                    bbox={"facecolor": 'white',
+                          "alpha": 0.8,
+                          "edgecolor": 'none',
+                          "pad": 2})
+
+    plt.xticks(rotation=45)
+
+    if save_path:
+        plt.savefig(save_path, bbox_inches='tight')
+        logger.info(f"Plot saved to {save_path}")
+    else:
+        plt.show()
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(filename)s:%(lineno)s/%(funcName)-s()] [%(levelname)s] %(message)s',
+        handlers=[
+            logging.StreamHandler()  # Outputs logs to the console
+        ]
+    )
+
+    parser = argparse.ArgumentParser(description='Plot CSV data columns')
+    parser.add_argument('data_file', help='Input CSV file')
+    parser.add_argument('--x-column', required=True,
+                        help='Column name for x-axis')
+    parser.add_argument('--y-column', required=True,
+                        help='Column name for y-axis')
+    parser.add_argument('--output', '-o',
+                        help='Path to save the output plot')
+    parser.add_argument('--title', '-t', default='Data Plot',
+                        help='Title for the graph')
+    parser.add_argument('--x-label',
+                        help='Label for x-axis (index starting from 0, or the exact column name)')
+    parser.add_argument('--y-label',
+                        help='Label for y-axis (index starting from 0, or the exact column name)')
+    parser.add_argument('--key-points', '-k', nargs=2, action='append',
+                        metavar=('VALUE', 'LABEL'),
+                        help='Key points to mark with vertical labels')
+    parser.add_argument('--y-min', type=float,
+                        help='Minimum value for y-axis')
+    parser.add_argument('--y-max', type=float,
+                        help='Maximum value for y-axis')
+    parser.add_argument('--convert-memory', action='store_true',
+                        help='Convert y-axis values to appropriate memory units')
+    parser.add_argument('--zero-start', action='store_true',
+                       help='Add a zero value data point at the start')
+    parser.add_argument('--zero-end', action='store_true',
+                       help='Add a zero value data point at the end')
+
+    args = parser.parse_args()
+
+    key_points = []
+    if args.key_points:
+        for value, label in args.key_points:
+            key_points.append((float(value), label))
+
+    x_values, y_values = parse_csv_columns(
+        args.data_file,
+        args.x_column,
+        args.y_column,
+        zero_start=args.zero_start,
+        zero_end=args.zero_end
+    )
+
+    x_label = args.x_label if args.x_label else args.x_column
+    y_label = args.y_label if args.y_label else args.y_column
+
+    plot_data(
+        x_values=x_values,
+        y_values=y_values,
+        x_label=x_label,
+        y_label=y_label,
+        title=args.title,
+        save_path=args.output,
+        key_points=key_points,
+        y_min=args.y_min,
+        y_max=args.y_max,
+        convert_memory=args.convert_memory
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python/benchmarking/requirements.txt
+++ b/scripts/python/benchmarking/requirements.txt
@@ -5,8 +5,11 @@ kiwisolver==1.4.8
 matplotlib==3.10.3
 numpy==2.2.6
 packaging==25.0
+pandas==2.3.0
 pillow==11.2.1
 psutil==7.0.0
 pyparsing==3.2.3
 python-dateutil==2.9.0.post0
+pytz==2025.2
 six==1.17.0
+tzdata==2025.2

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMainWithHeapTracking.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMainWithHeapTracking.java
@@ -2,43 +2,38 @@ package com.amazonaws.kinesisvideo.demoapp;
 
 import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
-import com.amazonaws.kinesisvideo.demoapp.contants.DemoTrackInfos;
-import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.demoapp.auth.AuthHelper;
+import com.amazonaws.kinesisvideo.demoapp.debug.StatsWriter;
+import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
+import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
 import com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory;
-import com.amazonaws.kinesisvideo.java.mediasource.file.AudioVideoFileMediaSource;
-import com.amazonaws.kinesisvideo.java.mediasource.file.AudioVideoFileMediaSourceConfiguration;
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSource;
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSourceConfiguration;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Optional;
-
-import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.ABSOLUTE_TIMECODES;
 
 /**
  * Demo Java Producer.
  */
-public final class DemoAppMain {
+public final class DemoAppMainWithHeapTracking {
 
-    private static final Logger log = LogManager.getLogger(DemoAppMain.class);
+    private static final Logger log = LogManager.getLogger(DemoAppMainWithHeapTracking.class);
 
-    // Use a different stream name when testing audio/video sample
     private static final String STREAM_NAME = Optional.ofNullable(System.getProperty("kvs-stream")).orElse("");
     private static final int FPS_25 = 25;
-    private static final int RETENTION_ONE_HOUR = 1;
     private static final String IMAGE_DIR = "src/main/resources/data/h264/";
-    private static final String FRAME_DIR = "src/main/resources/data/audio-video-frames";
-    // CHECKSTYLE:SUPPRESS:LineLength
-    // Need to get key frame configured properly so the output can be decoded. h264 files can be decoded using gstreamer plugin
-    // gst-launch-1.0 rtspsrc location="YourRtspUri" short-header=TRUE protocols=tcp ! rtph264depay ! decodebin ! videorate ! videoscale ! vtenc_h264_hw allow-frame-reordering=FALSE max-keyframe-interval=25 bitrate=1024 realtime=TRUE ! video/x-h264,stream-format=avc,alignment=au,profile=baseline,width=640,height=480,framerate=1/25 ! multifilesink location=./frame-%03d.h264 index=1
     private static final String IMAGE_FILENAME_FORMAT = "frame-%03d.h264";
     private static final int START_FILE_INDEX = 1;
     private static final int END_FILE_INDEX = 375;
+    private static final boolean USE_INSTRUMENTED_ALLOCATORS = true;
+    private static final Duration DEFAULT_DEFAULT_MALLOC_POLLING_INTERVAL = Duration.ofMillis(200);
 
     private static final Duration DEFAULT_DURATION_TO_STREAM = Duration.ofSeconds(10);
     private static final Duration DURATION_TO_STREAM = Optional.ofNullable(System.getProperty("stream-duration-ms"))
@@ -51,8 +46,21 @@ public final class DemoAppMain {
                 }
             })
             .orElse(DEFAULT_DURATION_TO_STREAM);
+    private static final String MALLOC_DATA_OUTPUT_PATH = Optional.ofNullable(System.getProperty("malloc-data-output-path"))
+            .filter(s -> !StringUtils.isNullOrEmpty(s))
+            .orElse("./memory-data.csv");
+    private static final Duration MALLOC_DATA_POLLING_INTERVAL = Optional.ofNullable(System.getProperty("malloc-polling-interval-ms"))
+            .map(value -> {
+                try {
+                    return Duration.ofMillis(Long.parseLong(value));
+                } catch (final NumberFormatException e) {
+                    log.error("Invalid malloc polling interval value: {}. Using default {} ms.", value, DEFAULT_DEFAULT_MALLOC_POLLING_INTERVAL.toMillis());
+                    return null;
+                }
+            })
+            .orElse(DEFAULT_DEFAULT_MALLOC_POLLING_INTERVAL);
 
-    private DemoAppMain() {
+    private DemoAppMainWithHeapTracking() {
         throw new UnsupportedOperationException();
     }
 
@@ -65,28 +73,27 @@ public final class DemoAppMain {
                             AuthHelper.getSystemPropertiesCredentialsProvider(),
                             null,
                             true,
-                            IPVersionFilter.IPV4_AND_IPV6);
+                            IPVersionFilter.IPV4_AND_IPV6,
+                            USE_INSTRUMENTED_ALLOCATORS);
 
-            // create a media source. this class produces the data and pushes it into
-            // Kinesis Video Producer lower level components
-            final MediaSource mediaSource = createImageFileMediaSource();
+            try (final StatsWriter statsWriter = new StatsWriter(MALLOC_DATA_OUTPUT_PATH,
+                    MALLOC_DATA_POLLING_INTERVAL, (NativeKinesisVideoClient) kinesisVideoClient)) {
 
-            // Audio/Video sample is available for playback on HLS (Http Live Streaming)
-            //final MediaSource mediaSource = createFileMediaSource();
+                final MediaSource mediaSource = createImageFileMediaSource();
+                kinesisVideoClient.registerMediaSource(mediaSource);
+                mediaSource.start();
 
-            // register media source with Kinesis Video Client
-            kinesisVideoClient.registerMediaSource(mediaSource);
+                log.info("Main thread sleeping {} ms.", DURATION_TO_STREAM.toMillis());
+                Thread.sleep(DURATION_TO_STREAM.toMillis());
 
-            // start streaming
-            mediaSource.start();
+                log.info("Stopping stream...");
+                mediaSource.stop();
+                kinesisVideoClient.unregisterMediaSource(mediaSource);
 
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
 
-            log.info("Main thread sleeping {} ms.", DURATION_TO_STREAM.toMillis());
-            Thread.sleep(DURATION_TO_STREAM.toMillis());
-
-            log.info("Stopping stream...");
-            mediaSource.stop();
-            kinesisVideoClient.unregisterMediaSource(mediaSource);
             kinesisVideoClient.free();
         } catch (final KinesisVideoException | InterruptedException e) {
             throw new RuntimeException(e);
@@ -115,23 +122,4 @@ public final class DemoAppMain {
         return mediaSource;
     }
 
-    /**
-     * Create a MediaSource based on local sample H.264 frames and AAC frames.
-     *
-     * @return a MediaSource backed by local H264 and AAC frame files
-     */
-    private static MediaSource createFileMediaSource() {
-        final AudioVideoFileMediaSourceConfiguration configuration =
-                new AudioVideoFileMediaSourceConfiguration.AudioVideoBuilder()
-                        .withDir(FRAME_DIR)
-                        .withRetentionPeriodInHours(RETENTION_ONE_HOUR)
-                        .withAbsoluteTimecode(ABSOLUTE_TIMECODES)
-                        .withTrackInfoList(DemoTrackInfos.createTrackInfoList())
-                        .withAllowStreamCreation(false)
-                        .build();
-        final AudioVideoFileMediaSource mediaSource = new AudioVideoFileMediaSource(STREAM_NAME);
-        mediaSource.configure(configuration);
-
-        return mediaSource;
-    }
 }

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/debug/StatsWriter.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/debug/StatsWriter.java
@@ -1,0 +1,148 @@
+package com.amazonaws.kinesisvideo.demoapp.debug;
+
+import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoMetrics;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Writes the current heap memory count to the file (bytes), along with a timestamp.
+ * This class provides a way to monitor memory allocation of a KinesisVideoClient
+ * by periodically writing the allocation size to a specified file in a csv-format.
+ * <p>
+ * This class will spawn a new thread to record the metrics, and terminate that thread once
+ * {@link #close()} is called.
+ */
+public class StatsWriter implements AutoCloseable {
+    private static final Logger log = LogManager.getLogger(StatsWriter.class);
+
+    private final String filePath;
+    private final long pollingIntervalMs;
+    private final NativeKinesisVideoClient kinesisVideoClient;
+    private final ScheduledExecutorService scheduler;
+    private final BufferedWriter writer;
+    private final List<String> streamNames;
+    private ScheduledFuture<?> scheduledTask;
+
+    /**
+     * Creates a new HeapWriter instance.
+     *
+     * @param filePath           The path to the file where heap information will be written
+     * @param pollingIntervalMs  The interval in milliseconds between heap measurements
+     * @param kinesisVideoClient The KinesisVideoClient instance to monitor
+     * @throws IOException If there's an error creating or opening the output file
+     */
+    public StatsWriter(@Nonnull final String filePath,
+                       @Nonnull final Duration pollingIntervalMs,
+                       @Nonnull final NativeKinesisVideoClient kinesisVideoClient) throws IOException {
+        this.filePath = filePath;
+        this.pollingIntervalMs = pollingIntervalMs.toMillis();
+        this.kinesisVideoClient = kinesisVideoClient;
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread thread = new Thread(r, "HeapWriter-Thread");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        final Path path = Paths.get(filePath);
+        if (Files.isDirectory(path)) {
+            throw new IllegalArgumentException("Path should be a file name: " + path);
+        }
+        Files.createDirectories(path);
+        Files.deleteIfExists(path);
+        this.writer = new BufferedWriter(new FileWriter(filePath, false));
+
+        this.streamNames = kinesisVideoClient.getStreamNames();
+
+        writeStatsHeader();
+        startMonitoring();
+    }
+
+    /**
+     * Starts the periodic monitoring of heap allocation.
+     */
+    private void startMonitoring() {
+        scheduledTask = scheduler.scheduleAtFixedRate(
+                this::writeHeapInfo,
+                0,
+                pollingIntervalMs,
+                TimeUnit.MILLISECONDS
+        );
+        log.info("Started heap monitoring with interval of {}ms, writing to {}", pollingIntervalMs, filePath);
+    }
+
+    private void writeStatsHeader() {
+        try {
+            final long contentStoreSizeBytes = kinesisVideoClient.getClientMetrics()
+                    .map(KinesisVideoMetrics::getContentStoreSize)
+                    .orElse(0L);
+            final String entry = String.format("Timestamp,Malloc Usage (Bytes),Content Store Used (Bytes out of %d)%n", contentStoreSizeBytes);
+            writer.write(entry);
+            writer.flush();
+        } catch (final IOException e) {
+            log.error("Failed to write heap information", e);
+        } catch (final Exception e) {
+            log.error("Unexpected error while writing heap information", e);
+        }
+    }
+
+    /**
+     * Writes the current heap information to the file.
+     */
+    private void writeHeapInfo() {
+        try {
+            final long allocationSize = kinesisVideoClient.getCurrentAllocationSizeBytes();
+            final long contentStoreUsedBytes = kinesisVideoClient.getClientMetrics()
+                    .map(KinesisVideoMetrics::getContentStoreAllocatedSize)
+                    .orElse(0L);
+            final String entry = String.format("%s,%d,%d%n", Instant.now().toString(), allocationSize, contentStoreUsedBytes);
+            writer.write(entry);
+            writer.flush();
+        } catch (final IOException e) {
+            log.error("Failed to write heap information", e);
+        } catch (final Exception e) {
+            log.error("Unexpected error while writing heap information", e);
+        }
+    }
+
+    /**
+     * Stops the monitoring and closes all resources.
+     */
+    @Override
+    public void close() {
+        try {
+            if (scheduledTask != null) {
+                scheduledTask.cancel(false);
+            }
+            scheduler.shutdown();
+            try {
+                if (!scheduler.awaitTermination(2 * pollingIntervalMs + 500, TimeUnit.MILLISECONDS)) {
+                    scheduler.shutdownNow();
+                }
+            } catch (final InterruptedException e) {
+                scheduler.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+
+            writer.close();
+            log.info("Heap monitoring stopped and resources cleaned up");
+        } catch (final IOException e) {
+            log.error("Error while closing HeapWriter", e);
+        }
+    }
+}

--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/debug/StatsWriter.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/debug/StatsWriter.java
@@ -9,6 +9,7 @@ import javax.annotation.Nonnull;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,7 +64,11 @@ public class StatsWriter implements AutoCloseable {
         if (Files.isDirectory(path)) {
             throw new IllegalArgumentException("Path should be a file name: " + path);
         }
-        Files.createDirectories(path);
+        try {
+            Files.createDirectories(path);
+        } catch (final FileAlreadyExistsException ex) {
+            // Ignore
+        }
         Files.deleteIfExists(path);
         this.writer = new BufferedWriter(new FileWriter(filePath, false));
 

--- a/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/KinesisVideoClientConfiguration.java
@@ -20,6 +20,7 @@ public final class KinesisVideoClientConfiguration {
     private final StorageCallbacks storageCallbacks;
     private final String endpoint;
     private final IPVersionFilter ipVersionFilter;
+    private final boolean isInstrumentedAllocatorsEnabled;
 
     private KinesisVideoClientConfiguration(final Builder builder) {
         this.region = builder.region;
@@ -27,6 +28,7 @@ public final class KinesisVideoClientConfiguration {
         this.storageCallbacks = builder.storageCallbacks;
         this.endpoint = builder.endpoint;
         this.ipVersionFilter = builder.ipVersionFilter;
+        this.isInstrumentedAllocatorsEnabled = builder.useInstrumentedAllocators;
     }
 
     public static Builder builder() {
@@ -97,6 +99,8 @@ public final class KinesisVideoClientConfiguration {
         return this.ipVersionFilter;
     }
 
+    public boolean isInstrumentedAllocatorsEnabled() { return this.isInstrumentedAllocatorsEnabled;}
+
     @Override
     public String toString() {
         return "KinesisVideoClientConfiguration{" +
@@ -105,6 +109,7 @@ public final class KinesisVideoClientConfiguration {
                 ", storageCallbacks=" + (storageCallbacks != null ? storageCallbacks.getClass().getSimpleName() : "null") +
                 ", endpoint='" + endpoint + '\'' +
                 ", ipVersionFilter=" + ipVersionFilter +
+                ", isInstrumentedAllocatorsEnabled=" + isInstrumentedAllocatorsEnabled +
                 '}';
     }
 
@@ -116,6 +121,7 @@ public final class KinesisVideoClientConfiguration {
         private String endpoint;
         private Optional<Boolean> isLegacyEndpoint = Optional.empty();
         private IPVersionFilter ipVersionFilter;
+        private boolean useInstrumentedAllocators = false;
 
         public Builder withRegion(final String region) {
             this.region = region;
@@ -144,6 +150,11 @@ public final class KinesisVideoClientConfiguration {
 
         public Builder withIPVersionFilter(final IPVersionFilter ipVersionFilter) {
             this.ipVersionFilter = ipVersionFilter;
+            return this;
+        }
+
+        public Builder useInstrumentedAllocators() {
+            this.useInstrumentedAllocators = true;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/client/NativeKinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/client/NativeKinesisVideoClient.java
@@ -7,7 +7,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -16,6 +19,9 @@ import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceConfiguration;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoMetrics;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoStreamMetrics;
+import com.amazonaws.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
@@ -66,6 +72,11 @@ public class NativeKinesisVideoClient extends AbstractKinesisVideoClient {
     private final ServiceCallbacks mServiceCallbacks;
 
     /**
+     * Whether to use PIC instrumented allocators.
+     */
+    private final boolean mUseInstrumentedAllocators;
+
+    /**
      * Underlying Kinesis Video producer object.
      */
     private KinesisVideoProducer kinesisVideoProducer;
@@ -100,6 +111,16 @@ public class NativeKinesisVideoClient extends AbstractKinesisVideoClient {
             @Nonnull final StorageCallbacks storageCallbacks,
             @Nonnull final ServiceCallbacks serviceCallbacks,
             @Nonnull final StreamCallbacks streamCallbacks) {
+        this(log, authCallbacks, storageCallbacks, serviceCallbacks, streamCallbacks, false);
+    }
+
+    public NativeKinesisVideoClient(
+            @Nonnull final Logger log,
+            @Nonnull final AuthCallbacks authCallbacks,
+            @Nonnull final StorageCallbacks storageCallbacks,
+            @Nonnull final ServiceCallbacks serviceCallbacks,
+            @Nonnull final StreamCallbacks streamCallbacks,
+            final boolean useInstrumentedAllocators) {
 
         super(log);
 
@@ -109,6 +130,7 @@ public class NativeKinesisVideoClient extends AbstractKinesisVideoClient {
         mStreamCallbacks = checkNotNull(streamCallbacks);
 
         mMediaSourceToStreamMap = new HashMap<MediaSource, KinesisVideoProducerStream>();
+        mUseInstrumentedAllocators = useInstrumentedAllocators;
     }
 
     /**
@@ -235,8 +257,86 @@ public class NativeKinesisVideoClient extends AbstractKinesisVideoClient {
                 mAuthCallbacks,
                 mStorageCallbacks,
                 mServiceCallbacks,
-                mLog);
+                mLog,
+                new CountDownLatch(1),
+                mUseInstrumentedAllocators);
         kinesisVideoProducer.createSync(deviceInfo);
         return kinesisVideoProducer;
+    }
+
+    /**
+     * Query the PIC malloc tracker for the current allocated bytes.
+     * Note this is shared for all streams.
+     *
+     * @return The current malloc'd memory for the KVS native codebase (global), in bytes.
+     */
+    public long getCurrentAllocationSizeBytes() {
+        if (!mUseInstrumentedAllocators) {
+            throw new IllegalStateException("Instrumented allocators from PIC are not enabled");
+        }
+        return ((NativeKinesisVideoProducerJni) kinesisVideoProducer).getCurrentAllocationBytes();
+    }
+
+    /**
+     * Get metrics for the producer client.
+     *
+     * @return Client metrics
+     */
+    public Optional<KinesisVideoMetrics> getClientMetrics() {
+        try {
+            return Optional.of(kinesisVideoProducer.getMetrics());
+        } catch (final KinesisVideoException ex) {
+            mLog.error("getClientMetrics failed with exception", ex);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get metrics for a particular stream.
+     *
+     * @param streamName name of the stream to fetch metrics of
+     * @return The metrics
+     * @throws IllegalArgumentException if the media source is not registered
+     */
+    public Optional<KinesisVideoStreamMetrics> getStreamMetrics(@Nonnull final String streamName) {
+
+        final MediaSource mediaSource = mMediaSources.stream()
+                .filter(ms -> {
+                    try {
+                        return streamName.equals(ms.getStreamInfo().getName());
+                    } catch (final KinesisVideoException e) {
+                        return false;
+                    }
+                })
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No stream found for media source " + streamName));
+
+        final long streamHandle = mMediaSourceToStreamMap.get(mediaSource).getStreamHandle();
+        final KinesisVideoStreamMetrics metrics = new KinesisVideoStreamMetrics();
+        try {
+            ((NativeKinesisVideoProducerJni) kinesisVideoProducer).getStreamMetrics(streamHandle, metrics);
+            return Optional.of(metrics);
+        } catch (final KinesisVideoException e) {
+            mLog.error("Failed to get stream metrics for media source {}", mediaSource);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns a copy of the current registered streams.
+     *
+     * @return A list of the stream names currently registered.
+     */
+    public List<String> getStreamNames() {
+        return mMediaSources.stream()
+                .map(mediaSource -> {
+                    try {
+                        return mediaSource.getStreamInfo().getName();
+                    } catch (final KinesisVideoException e) {
+                        return null;
+                    }
+                })
+                .filter(s -> !StringUtils.isNullOrEmpty(s))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
@@ -130,6 +130,11 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
     private DeviceInfo mDeviceInfo;
 
     /**
+     * If using the custom allocators from PIC.
+     */
+    private boolean mIsTrackingMallocs;
+
+    /**
      * Public constructor.
      * @param authCallbacks Authentication callbacks
      * @param storageCallbacks Storage callbacks
@@ -179,6 +184,25 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
                                          final @Nonnull ServiceCallbacks serviceCallbacks,
                                          final @Nonnull Logger log,
                                          final @Nonnull CountDownLatch readyLatch) throws ProducerException {
+        this(authCallbacks, storageCallbacks, serviceCallbacks, log, readyLatch, false);
+    }
+
+    /**
+     * Public constructor
+     * @param authCallbacks Authentication callbacks
+     * @param storageCallbacks Storage callbacks
+     * @param serviceCallbacks Service call callbacks
+     * @param log log object to use for logging
+     * @param readyLatch Ready latch for synch creation
+     * @param isTrackingMallocs Whether to set up PIC's instrumented allocators
+     * @throws ProducerException
+     */
+    public NativeKinesisVideoProducerJni(final @Nonnull AuthCallbacks authCallbacks,
+                                         final @Nonnull StorageCallbacks storageCallbacks,
+                                         final @Nonnull ServiceCallbacks serviceCallbacks,
+                                         final @Nonnull Logger log,
+                                         final @Nonnull CountDownLatch readyLatch,
+                                         final boolean isTrackingMallocs) throws ProducerException {
         mLog = Preconditions.checkNotNull(log);
         mAuthCallbacks = Preconditions.checkNotNull(authCallbacks);
         mStorageCallbacks = Preconditions.checkNotNull(storageCallbacks);
@@ -187,6 +211,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         mLibraryLoader = new NativeLibraryLoader(mLog);
         mServiceCallbacks.initialize(this);
         mKinesisVideoMetrics = new KinesisVideoMetrics();
+        mIsTrackingMallocs = isTrackingMallocs;
     }
 
     /**
@@ -229,6 +254,10 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
 
                 // We are initialized
                 mLibraryInitialized = true;
+            }
+
+            if (mIsTrackingMallocs) {
+                setupInstrumentedAllocators();
             }
 
             mClientHandle = createKinesisVideoClient(deviceInfo);
@@ -1511,4 +1540,17 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
     private native void kinesisVideoStreamTerminated(long clientHandle, long streamHandle, long uploadHandle,
                                                      int statusCode)
             throws ProducerException;
+
+    /**
+     * Overrides malloc and free with a custom one for tracking purposes.
+     */
+    public static native void setupInstrumentedAllocators();
+
+    /**
+     * Return the current value of the allocated memory.
+     * Note: Due to lazy memory allocation, this may not accurately reflect the current RSS usage.
+     *
+     * @return the current memory currently malloc'd by the native codebase in bytes.
+     */
+    public native long getCurrentAllocationBytes();
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/client/JavaKinesisVideoClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/client/JavaKinesisVideoClient.java
@@ -3,25 +3,26 @@ package com.amazonaws.kinesisvideo.java.client;
 import com.amazonaws.kinesisvideo.auth.DefaultAuthCallbacks;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
-import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks;
-import com.amazonaws.kinesisvideo.producer.StreamCallbacks;
 import com.amazonaws.kinesisvideo.internal.producer.client.KinesisVideoServiceClient;
 import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.producer.StreamCallbacks;
+import com.amazonaws.kinesisvideo.streaming.DefaultStreamCallbacks;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Implement Kinesis Video Client interface for Java.
- *
+ * <p>
  * Main purpose of this class is to manage media sources and their configuration.
- *
+ * <p>
  * Media source produces the stream of data which is uploaded into Kinesis Video using this and underlying
  * classes and producer SDK. Stream of data produced by the media source can be anything,
  * for example, video, sound, sensor data, logs, etc. Kinesis Video is agnostic to
  * the internal format of the data.
- *
+ * <p>
  * This client wraps the calls to the back-end, managing the device and network configuration,
  * creating, registering, and controlling all streams at once
  */
@@ -32,10 +33,11 @@ public final class JavaKinesisVideoClient extends NativeKinesisVideoClient {
             @Nonnull final KinesisVideoClientConfiguration configuration,
             @Nonnull final KinesisVideoServiceClient serviceClient,
             @Nonnull final ScheduledExecutorService executor) {
-        super(log,
+        this(log,
                 configuration,
                 serviceClient,
-                executor);
+                executor,
+                new DefaultStreamCallbacks());
     }
 
     public JavaKinesisVideoClient(
@@ -63,6 +65,7 @@ public final class JavaKinesisVideoClient extends NativeKinesisVideoClient {
                         log),
                 configuration.getStorageCallbacks(),
                 serviceCallbacks,
-                streamCallbacks);
+                streamCallbacks,
+                configuration.isInstrumentedAllocatorsEnabled());
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
@@ -61,7 +61,7 @@ public final class KinesisVideoJavaClientFactory {
     /**
      * Create Kinesis Video client.
      *
-     * @param regions Regions object
+     * @param regions                Regions object
      * @param awsCredentialsProvider Credentials provider
      * @return
      * @throws KinesisVideoException
@@ -98,6 +98,22 @@ public final class KinesisVideoJavaClientFactory {
             @Nullable final Boolean isLegacyEndpoint,
             @Nullable final IPVersionFilter ipVersionFilter)
             throws KinesisVideoException {
+        return createKinesisVideoClient(regions, awsCredentialsProvider, endpointOverride, isLegacyEndpoint,
+                ipVersionFilter, false);
+    }
+
+    /**
+     * Create Kinesis Video client.
+     */
+    @Nonnull
+    public static KinesisVideoClient createKinesisVideoClient(
+            @Nonnull final Regions regions,
+            @Nonnull final AWSCredentialsProvider awsCredentialsProvider,
+            @Nullable final String endpointOverride,
+            @Nullable final Boolean isLegacyEndpoint,
+            @Nullable final IPVersionFilter ipVersionFilter,
+            final boolean useInstrumentedAllocators)
+            throws KinesisVideoException {
         Preconditions.checkNotNull(regions);
         Preconditions.checkNotNull(awsCredentialsProvider);
 
@@ -117,6 +133,10 @@ public final class KinesisVideoJavaClientFactory {
             builder.withEndpoint(endpointOverride);
         } else {
             builder.withIsLegacyEndpoint(isLegacyEndpoint);
+        }
+
+        if (useInstrumentedAllocators) {
+            builder.useInstrumentedAllocators();
         }
 
         final KinesisVideoClientConfiguration configuration = builder.build();
@@ -171,7 +191,7 @@ public final class KinesisVideoJavaClientFactory {
         Preconditions.checkNotNull(deviceInfo);
         Preconditions.checkNotNull(executor);
 
-        final Logger log =  LogManager.getLogger(KinesisVideoJavaClientFactory.class);
+        final Logger log = LogManager.getLogger(KinesisVideoJavaClientFactory.class);
 
         final JavaKinesisVideoServiceClient serviceClient = new JavaKinesisVideoServiceClient(log);
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
1. Added a new client parameter to setup PIC's custom memory allocators setup
      - This will override the malloc and calloc with a [custom one](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/utils/src/InstrumentedAllocators.c#L11).
      - Propagate this new parameter all the way down
      - Add new JNI methods.
2. Expose the stream and client stats to the application layer.
3. Create new sample that polls the stats and saves it to a csv file
      - Currently, saving the current malloc usage, and content view usage. The sample is easily modifiable to be able to  expand to write more stats in the future.
5. Created a new script that parses the csv file and generates a graph
6. Added the new sample to the CI
7. Upload also the raw data file to the CI artifacts

*Why was it changed?*
1. To be able to get a better insight into the native memory usage.
2. To be able to grab the metrics and save it to a file to be used in the report.
3. Didn't want to clutter up the existing DemoAppMain
4. I wanted to make a more flexible script that lets me choose which column to plot rather than hard-coded columns in the other script.
5. To automate the report generation.
6. To be able to re-format the graph afterwards if needed.

*How was it changed?*
1. A new KinesisVideoClientConfiguration parameter was added, which gets propagated similar to the IPV4/IPV6 flag. If specified, it will call the method from PIC that overrides the malloc and calloc with the custom one.
2. Added a method to return these. Previous, they are just printed to the logs every keyframe in the putFrame call.
     - It uses Optionals for more idiomatic approach.
     - For stream metrics, chose to use the stream name as the key instead of the media source.
4. Copied DemoAppMain, but also created StatsWriter class in the demo folder which saves some stats to a file. It creates a new thread that periodically polls the client for stats and saves it to the file.
5. The script is similar to the older one, except you can specify the column name or the column index for the x- and y-axises.
6. Added a new matrix entry. Since only the new sample generates the heap data, added the conditions to only run the new graph generation script to the new one.
7. Moved the raw data files and graphs into a new folder, which the entire folder will get compressed when uploaded as a GitHub actions artifact.

*What testing was done for the changes?*
- Generated graphs locally.
- Ran the CI on a fork and confirmed the zip files are getting uploaded correctly.

Sample graph:

![content-store-usage](https://github.com/user-attachments/assets/b0d8788c-2385-416b-9d20-a831a63e0e25)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
