### PR TITLE
Scripts fix: Normalize CPU to 100%

### DIFF
--- a/scripts/python/benchmarking/capture_rss_and_cpu.py
+++ b/scripts/python/benchmarking/capture_rss_and_cpu.py
@@ -48,18 +48,17 @@ class ProcessMonitor:
         self.cpu_count_logical = cpu_count()
 
         cpu_count_physical = cpu_count(logical=False)  # physical cores only
-        self.cpu_percentage_max = self.cpu_count_logical * 100
 
         print(f"Number of CPU cores: {cpu_count_physical} physical, {self.cpu_count_logical} logical")
-        print(f"Maximum possible CPU%: {self.cpu_percentage_max}%")
+        print(f"Maximum possible CPU%: {self.cpu_count_logical * 100}%")
 
-        if self.cpu_percentage_max > 100:
+        if self.cpu_count_logical > 1:
             print(f"It will be normalized to 100%")
 
     def get_process_metrics(self) -> tuple[str, float, float] | None:
         """
         Collect current process metrics.
-        The CPU percent is on 0-1 range.
+        The CPU percent is on 0-100 range.
 
         Returns:
             tuple: (timestamp, memory_mb, cpu_percent) or None if process not found
@@ -70,7 +69,7 @@ class ProcessMonitor:
 
             if self.pid is None:
                 # System-wide monitoring
-                # cpu_percent() returns value between 0-100. We need 0-1 value
+                # cpu_percent() returns value between 0-100.
                 cpu_percent = psutil.cpu_percent(interval=self.interval)
 
                 total_rss = 0
@@ -90,7 +89,7 @@ class ProcessMonitor:
                 process = Process(self.pid)
                 cpu_percent = process.cpu_percent(interval=self.interval)
 
-                normalized_cpu_percent = cpu_percent / self.cpu_percentage_max
+                normalized_cpu_percent = cpu_percent / self.cpu_count_logical
                 memory_kb = process.memory_info().rss / 1024
                 return timestamp, memory_kb, normalized_cpu_percent
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Script for capturing the CPU% for the benchmarking scripts

*Why was it changed?*
- The scaling was off in the graphs, basically always showing that almost no CPU is being used at all points in the application.

*How was it changed?*
- Normalize from 0-1 range to 0-100 range.

*What testing was done for the changes?*
- Spot-checked some graphs generated by the CI: 

![producer-java-ubuntu-22 04-java-11_DemoAppMainWithHeapTracking-mem-cpu](https://github.com/user-attachments/assets/609a0a56-3ba9-487e-ba15-514c70503ee3)

![producer-java-macos-latest-java-11_DemoAppMain-mem-cpu](https://github.com/user-attachments/assets/2c72e0bc-9e50-41fe-9352-ddb72bff836f)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
