### PR TITLE
Additional logging for scheduled executor service tasks and Error handling

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -16,7 +16,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="DEBUG">
+        <Root level="WARN">
             <AppenderRef ref="ConsoleAppender"/>
             <AppenderRef ref="RollingFile"/>
         </Root>

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -16,7 +16,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="WARN">
+        <Root level="DEBUG">
             <AppenderRef ref="ConsoleAppender"/>
             <AppenderRef ref="RollingFile"/>
         </Root>

--- a/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
@@ -76,6 +76,7 @@ public final class PutMediaClient {
         clientBuilder.header(FRAGMENT_TIME_CODE_TYPE_HEADER, mBuilder.mFragmentTimecodeType);
         clientBuilder.completionCallback(mBuilder.mCompletion);
         clientBuilder.setSenderCallback(sender);
+        clientBuilder.setStreamName(mBuilder.mStreamName);
         clientBuilder.setIPVersionFilter(mBuilder.mIPVersionFilter);
         // Timeout if no response is received from the server for put(i.e., acks)
         // Socket will/should be closed by the consumer by throwing the SocketTimeoutException

--- a/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
@@ -4,6 +4,7 @@ import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults;
 import com.amazonaws.kinesisvideo.common.function.Consumer;
 import com.amazonaws.kinesisvideo.socket.SocketFactory;
+import com.amazonaws.kinesisvideo.util.LoggedExitRunnable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -140,17 +141,17 @@ public final class ParallelSimpleHttpClient implements HttpClient {
     private void sendPayloadInBackground() {
         if (mBuilder.mSender != null) {
             payloadSender = Executors.newFixedThreadPool(1);
-            payloadSender.execute(new Runnable() {
+            payloadSender.execute(new LoggedExitRunnable("PutMedia-Sending-" + mBuilder.mStreamName) {
                 @Override
-                public void run() {
+                public void execute() {
                     Exception storedException = null;
                     try {
                         // This is needed to get the thread Id.
-                        log.debug("Start sending data.");
+                        log.debug("[{}] Start sending data.", mBuilder.mStreamName);
                         mBuilder.mSender.accept(mOutputStream);
-                        log.debug("End sending data. Sent all data, close.");
+                        log.debug("[{}] End sending data. Sent all data, close.", mBuilder.mStreamName);
                     } catch (final Exception e) {
-                        log.error("Exception thrown on sending thread", e);
+                        log.error("[{}] Exception thrown on sending thread", mBuilder.mStreamName, e);
                         storedException = e;
                     } finally {
                         //Only call completion if there is an exception, otherwise sender will call completion
@@ -167,16 +168,16 @@ public final class ParallelSimpleHttpClient implements HttpClient {
     private void receiveResponseInBackground() {
         if (mBuilder.mReceiver != null) {
             responseReceiver = Executors.newFixedThreadPool(1);
-            responseReceiver.execute(new Runnable() {
+            responseReceiver.execute(new LoggedExitRunnable("PutMedia-Receiving-" + mBuilder.mStreamName) {
                 @Override
-                public void run() {
+                public void execute() {
                     Exception storedException = null;
                     try {
-                        log.debug("Starting receiving data");
+                        log.debug("[{}] Starting receiving data", mBuilder.mStreamName);
                         mBuilder.mReceiver.accept(mInputStream);
-                        log.debug("Received all data, close");
+                        log.debug("[{}] Received all data, close", mBuilder.mStreamName);
                     } catch (final Exception e) {
-                        log.error("Exception thrown on receiving thread", e);
+                        log.error("[{}] Exception thrown on receiving thread", mBuilder.mStreamName, e);
                         storedException = e;
                     } finally {
                         mBuilder.mCompletion.accept(storedException);
@@ -219,6 +220,7 @@ public final class ParallelSimpleHttpClient implements HttpClient {
         private Integer mTimeout;
         private IPVersionFilter mIPVersionFilter;
         private Consumer<Exception> mCompletion;
+        private String mStreamName = "";
         // TODO: Set to correct output channel
 
         private Builder() {
@@ -269,6 +271,11 @@ public final class ParallelSimpleHttpClient implements HttpClient {
 
         public Builder setIPVersionFilter(final IPVersionFilter ipVersionFilter) {
             mIPVersionFilter = ipVersionFilter;
+            return this;
+        }
+
+        public Builder setStreamName(final String streamName) {
+            mStreamName = streamName;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
@@ -6,6 +6,7 @@ import com.amazonaws.kinesisvideo.auth.StaticCredentialsProvider;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.common.function.Consumer;
+import com.amazonaws.kinesisvideo.util.LoggedExitRunnable;
 import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducer;
@@ -32,6 +33,7 @@ import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.ACCESS_DENIED;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_ACCESS_DENIED;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_BAD_REQUEST;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_NOT_FOUND;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_NOT_SET;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_OK;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.HTTP_RESOURCE_IN_USE;
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RESOURCE_IN_USE;
@@ -186,10 +188,10 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("CreateStream-" + streamName) {
             @Override
-            public void run() {
-                int statusCode;
+            public void execute() {
+                int statusCode = HTTP_NOT_SET;
                 String streamArn = null;
 
                 final KinesisVideoCredentialsProvider credentialsProvider = getCredentialsProvider(authData, log);
@@ -206,16 +208,17 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                             timeoutInMillis,
                             credentialsProvider);
                     statusCode = HTTP_OK;
-                } catch (final KinesisVideoException e) {
-                    statusCode = getStatusCodeFromException(e);
-                    log.error("Kinesis Video service client returned an error. Reporting to Kinesis Video PIC.", e);
-                }
-
-                try {
-                    kinesisVideoProducer.createStreamResult(customData, streamArn, statusCode);
-                } catch (final ProducerException e) {
-                    // TODO: Deal with the runtime exception properly in this and following cases
-                    throw new RuntimeException(e);
+                } catch (final Throwable t) {
+                    statusCode = getStatusCodeFromException(t);
+                    log.error("[{}] Kinesis Video service client (CreateStream) returned an error. Reporting to Kinesis Video PIC.", streamName, t);
+                } finally {
+                    try {
+                        kinesisVideoProducer.createStreamResult(customData, streamArn, statusCode);
+                    } catch (final ProducerException e) {
+                        // TODO: Deal with the runtime exception properly in this and following cases
+                        log.error("[{}] Encountered an issue notifying PIC the result of the CreateStream API call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -236,10 +239,10 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("DescribeStream-" + streamName) {
             @Override
-            public void run() {
-                int statusCode;
+            public void execute() {
+                int statusCode = HTTP_NOT_SET;
                 StreamDescription streamDescription = null;
 
                 final KinesisVideoCredentialsProvider credentialsProvider = getCredentialsProvider(authData, log);
@@ -250,15 +253,16 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                             timeoutInMillis,
                             credentialsProvider);
                     statusCode = HTTP_OK;
-                } catch (final KinesisVideoException e) {
-                    statusCode = getStatusCodeFromException(e);
-                    log.error("Kinesis Video service client returned an error. Reporting to Kinesis Video PIC.", e);
-                }
-
-                try {
-                    kinesisVideoProducer.describeStreamResult(stream, streamHandle, streamDescription, statusCode);
-                } catch (final ProducerException e) {
-                    throw new RuntimeException(e);
+                } catch (final Throwable t) {
+                    statusCode = getStatusCodeFromException(t);
+                    log.error("[{}] Kinesis Video service client (DescribeStream) returned an error. Reporting to Kinesis Video PIC.", streamName, t);
+                } finally {
+                    try {
+                        kinesisVideoProducer.describeStreamResult(stream, streamHandle, streamDescription, statusCode);
+                    } catch (final ProducerException e) {
+                        log.error("[{}] Encountered an issue notifying PIC the result of the DescribeStream API call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -280,9 +284,9 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("GetDataEndpoint-" + streamName) {
             @Override
-            public void run() {
+            public void execute() {
                 final KinesisVideoCredentialsProvider credentialsProvider = getCredentialsProvider(authData, log);
                 final long timeoutInMillis = timeout / Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
                 int statusCode = HTTP_OK;
@@ -292,20 +296,21 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                             apiName,
                             timeoutInMillis,
                             credentialsProvider);
-                } catch (final KinesisVideoException e) {
-                    log.error("Kinesis Video service client returned an error. Reporting to Kinesis Video PIC.", e);
-                    statusCode = getStatusCodeFromException(e);
-                }
+                } catch (final Throwable t) {
+                    log.error("[{}] Kinesis Video service client (GetDataEndpoint) returned an error. Reporting to Kinesis Video PIC.", streamName, t);
+                    statusCode = getStatusCodeFromException(t);
+                } finally {
+                    if (statusCode != HTTP_OK && isBlank(endpoint)) {
+                        // TODO: more URI validation
+                        statusCode = HTTP_NOT_FOUND;
+                    }
 
-                if (statusCode != HTTP_OK && isBlank(endpoint)) {
-                    // TODO: more URI validation
-                    statusCode = HTTP_NOT_FOUND;
-                }
-
-                try {
-                    kinesisVideoProducer.getStreamingEndpointResult(stream, streamHandle, endpoint, statusCode);
-                } catch (final ProducerException e) {
-                    throw new RuntimeException(e);
+                    try {
+                        kinesisVideoProducer.getStreamingEndpointResult(stream, streamHandle, endpoint, statusCode);
+                    } catch (final ProducerException e) {
+                        log.error("[{}] Encountered an issue notifying PIC the result of the GetDataEndpoint API call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -326,9 +331,9 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("GetStreamingToken-" + streamName) {
             @Override
-            public void run() {
+            public void execute() {
                 // Currently, we have no support for getting a streaming token. We will refresh the credentials
                 // and return a credential from the credentials provider we got initially.
                 final KinesisVideoCredentialsProvider credentialsProvider = configuration.getCredentialsProvider();
@@ -350,29 +355,28 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                     outputStream.flush();
                     serializedCredentials = byteArrayOutputStream.toByteArray();
                     outputStream.close();
-                } catch (final IOException e) {
-                    log.error(e);
-                } catch (final KinesisVideoException e) {
-                    log.error(e);
+                } catch (final Throwable t) {
+                    log.error("[{}] Encountered an error refreshing the credentials", streamName, t);
                 } finally {
                     try {
                         byteArrayOutputStream.close();
                     } catch (final IOException ex) {
                         // Do nothing
                     }
-                }
 
-                final int statusCode = HTTP_OK;
+                    final int statusCode = HTTP_OK;
 
-                try {
-                    kinesisVideoProducer.getStreamingTokenResult(
-                            stream,
-                            streamHandle,
-                            serializedCredentials,
-                            expiration,
-                            statusCode);
-                } catch (final ProducerException e) {
-                    throw new RuntimeException(e);
+                    try {
+                        kinesisVideoProducer.getStreamingTokenResult(
+                                stream,
+                                streamHandle,
+                                serializedCredentials,
+                                expiration,
+                                statusCode);
+                    } catch (final ProducerException e) {
+                        log.error("[{}] Encountered an issue notifying PIC the result of the credentials refresh call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -397,9 +401,9 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("PutMedia-" + streamName) {
             @Override
-            public void run() {
+            public void execute() {
 
                 if (kinesisVideoProducerStream == null) {
                     throw new IllegalStateException("Couldn't find the correct stream");
@@ -437,16 +441,17 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
 
                     // Block until we parse the headers
                     blockingAckConsumer.awaitResponse();
-                } catch (final KinesisVideoException e) {
-                    statusCode = getStatusCodeFromException(e);
-                    log.error("Kinesis Video service client returned an error. Reporting to Kinesis Video PIC.", e);
-                }
-
-                try {
-                    log.info("putStreamResult uploadHandle {} {}", clientUploadHandle, statusCode);
-                    kinesisVideoProducer.putStreamResult(kinesisVideoProducerStream, clientUploadHandle, statusCode);
-                } catch (final ProducerException e) {
-                    throw new RuntimeException(e);
+                } catch (final Throwable t) {
+                    statusCode = getStatusCodeFromException(t);
+                    log.error("[{}] Kinesis Video service client (PutMedia) returned an error. Reporting to Kinesis Video PIC.", streamName, t);
+                } finally {
+                    try {
+                        log.info("[{}] putStreamResult uploadHandle {} {}", streamName, clientUploadHandle, statusCode);
+                        kinesisVideoProducer.putStreamResult(kinesisVideoProducerStream, clientUploadHandle, statusCode);
+                    } catch (final ProducerException e) {
+                        log.error("[{}] Encountered an issue notifying PIC the result of the PutMedia API call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };
@@ -466,10 +471,11 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
 
         Preconditions.checkState(isInitialized(), "Service callbacks object should be initialized first");
         final long delay = calculateRelativeServiceCallAfter(callAfter);
+        final String streamName = stream.getStreamName();
 
-        final Runnable task = new Runnable() {
+        final Runnable task = new LoggedExitRunnable("TagStream-" + stream.getStreamName()) {
             @Override
-            public void run() {
+            public void execute() {
                 final KinesisVideoCredentialsProvider credentialsProvider = getCredentialsProvider(authData, log);
                 final long timeoutInMillis = timeout / Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
                 int statusCode = HTTP_OK;
@@ -488,20 +494,16 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
                             tagsMap,
                             timeoutInMillis,
                             credentialsProvider);
-                } catch (final KinesisVideoException e) {
-                    log.error("Kinesis Video service client returned an error. Reporting to Kinesis Video PIC.", e);
-                    statusCode = getStatusCodeFromException(e);
-                }
-
-                if (statusCode != HTTP_OK) {
-                    // TODO: more URI validation
-                    statusCode = HTTP_BAD_REQUEST;
-                }
-
-                try {
-                    kinesisVideoProducer.tagResourceResult(stream, streamHandle, statusCode);
-                } catch (final ProducerException e) {
-                    throw new RuntimeException(e);
+                } catch (final Throwable t) {
+                    log.error("[{}] Kinesis Video service client (TagStream) returned an error. Reporting to Kinesis Video PIC.", streamName, t);
+                    statusCode = getStatusCodeFromException(t);
+                } finally {
+                    try {
+                        kinesisVideoProducer.tagResourceResult(stream, streamHandle, statusCode);
+                    } catch (final ProducerException e) {
+                        log.error("[{}] Encountered an issue notifying PIC the result of the TagStream API call.", streamName, e);
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         };

--- a/src/main/java/com/amazonaws/kinesisvideo/java/service/JavaKinesisVideoServiceClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/service/JavaKinesisVideoServiceClient.java
@@ -283,11 +283,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
             createStreamResult = serviceClient.createStream(createStreamRequest);
         } catch (final AmazonClientException e) {
             // Wrap into an KinesisVideoException object
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (CreateStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("create stream result: {}", createStreamResult.toString());
+        log.debug("[{}] create stream result: {}", streamName, createStreamResult.toString());
 
         return createStreamResult.getStreamARN();
     }
@@ -312,7 +312,7 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             describeStreamResult = serviceClient.describeStream(describeStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (DescribeStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
@@ -321,7 +321,7 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
             return null;
         }
 
-        log.debug("describe stream result: {}", describeStreamResult.toString());
+        log.debug("[{}] describe stream result: {}", streamName, describeStreamResult.toString());
         return toStreamDescription(describeStreamResult);
     }
 
@@ -349,11 +349,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             deleteStreamResult = serviceClient.deleteStream(deleteStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (DeleteStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("delete stream result: {}", deleteStreamResult.toString());
+        log.debug("[{}] delete stream result: {}", streamName, deleteStreamResult.toString());
     }
 
     @Override
@@ -378,11 +378,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             tagStreamResult = serviceClient.tagStream(tagStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (TagStream) failed.", streamArn, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("tag resource result: {}", tagStreamResult.toString());
+        log.debug("[{}] tag resource result: {}", streamArn, tagStreamResult.toString());
     }
 
     @Override
@@ -408,11 +408,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             getDataEndpointResult = serviceClient.getDataEndpoint(getDataEndpointRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (GetDataEndpoint) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("get data endpoint result: {}", getDataEndpointResult.toString());
+        log.debug("[{}] get data endpoint result: {}", streamName, getDataEndpointResult.toString());
 
         return getDataEndpointResult.getDataEndpoint();
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/util/LoggedExitRunnable.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/util/LoggedExitRunnable.java
@@ -1,0 +1,86 @@
+package com.amazonaws.kinesisvideo.util;
+
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An abstract implementation of {@link Runnable} that provides structured logging
+ * for task execution. This class automatically logs entry and exit points of the task,
+ * as well as any errors that occur during execution.
+ *
+ * <p>This class is designed to wrap task execution with consistent logging patterns,
+ * making it easier to track and debug asynchronous operations. All exceptions are caught
+ * and logged, preventing them from propagating up the call stack.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * LoggedExitRunnable task = new LoggedExitRunnable("MyTask") {
+ *     {@literal @}Override
+ *     public void execute() {
+ *         // Task implementation here
+ *     }
+ * };
+ * executorService.submit(task);
+ * </pre>
+ *
+ * <p>The logging format follows the pattern:</p>
+ * <ul>
+ *   <li>On entry: [TaskName] Enter</li>
+ *   <li>On error: [TaskName] Encountered error running task</li>
+ *   <li>On exit: [TaskName] Leave</li>
+ * </ul>
+ *
+ * @see Runnable
+ */
+public abstract class LoggedExitRunnable implements Runnable {
+
+    private static final Logger log = LogManager.getLogger(LoggedExitRunnable.class);
+
+    private final String runnableTaskName;
+
+    /**
+     * Creates a new LoggedExitRunnable with the specified task name.
+     *
+     * @param runnableTaskName A descriptive name for the task that will appear in log messages.
+     *                         Should be unique enough to identify the specific task instance
+     *                         in log output.
+     * @throws NullPointerException if runnableTaskName is null
+     */
+    public LoggedExitRunnable(@Nonnull final String runnableTaskName) {
+        Preconditions.checkNotNull(runnableTaskName);
+        this.runnableTaskName = runnableTaskName;
+    }
+
+    /**
+     * Implements the {@link Runnable#run()} method with structured logging.
+     * This method handles the logging of entry and exit points, as well as any
+     * errors that occur during execution.
+     *
+     * <p>This implementation ensures that all exceptions are caught and logged,
+     * and that exit logging occurs even if an exception is thrown.</p>
+     */
+    @Override
+    public void run() {
+        log.debug("[{}] Enter", runnableTaskName);
+
+        try {
+            execute();
+        } catch (final Throwable t) {
+            log.error("[{}] Encountered error running task", runnableTaskName, t);
+            throw t;
+        } finally {
+            log.debug("[{}] Leave", runnableTaskName);
+        }
+    }
+
+    /**
+     * To be implemented by concrete classes to define the actual task execution logic.
+     *
+     * <p>Any uncaught exceptions thrown by this method will be caught, logged, and re-thrown
+     * (propagated) by the {@link #run()} method.</p>
+     */
+    public abstract void execute();
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/util/StreamInfoConstants.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/util/StreamInfoConstants.java
@@ -7,6 +7,7 @@ import static com.amazonaws.kinesisvideo.producer.Time.HUNDREDS_OF_NANOS_IN_A_SE
  * All the time unit used in this class is 100 ns (minimum unit used in producer SDK)
  */
 public final class StreamInfoConstants {
+    public static final int HTTP_NOT_SET = 0;
     public static final int HTTP_OK = 200;
     public static final int HTTP_BAD_REQUEST = 400;
     public static final int HTTP_NOT_FOUND = 404;

--- a/src/main/java/com/amazonaws/kinesisvideo/util/VersionUtil.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/util/VersionUtil.java
@@ -4,6 +4,7 @@ import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 public final class VersionUtil {
@@ -13,11 +14,16 @@ public final class VersionUtil {
     public static final String AWS_SDK_KVS_PRODUCER_VERSION_STRING;
 
     static {
-        try {
-            final Properties properties = new Properties();
-            properties.load(VersionUtil.class.getClassLoader().getResourceAsStream(POM_PROPERTIES_FILE));
+        final Properties properties = new Properties();
+
+        try (final InputStream pomPropertiesResource = VersionUtil.class.getClassLoader().getResourceAsStream(POM_PROPERTIES_FILE)) {
+            if (pomPropertiesResource == null) {
+                throw new ExceptionInInitializerError("The required resource file: '" + POM_PROPERTIES_FILE + "' was not found!");
+            }
+
+            properties.load(pomPropertiesResource);
             AWS_SDK_KVS_PRODUCER_VERSION_STRING = properties.getProperty(POM_PROPERTIES_VERSION_KEY);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new ExceptionInInitializerError("Unable to get project version from pom.xml: " + e);
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
- We encountered a case where the `pom.properties` was accidentally removed, and it resulted in timeouts. 
- For context, the Result system is the PIC's version of callback completion method.
- Because the initialization occurs in the static block, we have the `ExceptionInInitializer` getting thrown. The error was not caught (since we only catch Exceptions), the thread exited early and the Result notification to PIC never happened. The catch blocks were changed to Throwable instead. (The `getStatusCodeFromException()` method takes Throwable as an input). Also, moved the PIC notification into the `finally` block to make sure it always gets executed. 
- From our above experience, the ScheduledExecutorService appears to swallow all uncaught exceptions (not even printed), so added the LoggedExitRunnable to make sure all uncaught exceptions are always printed.

*What was changed?*
- Enhanced error handling and logging across service callback implementations
- Added new `LoggedExitRunnable` utility class for consistent logging of task execution
- Improved error messages in `VersionUtil`
- Added `HTTP_NOT_SET` constant from PIC
- Include stream name in some log messages

*Why was it changed?*
- To improve operational visibility and debugging capabilities
- To ensure consistent error handling and logging patterns across all service callbacks
- To improve code reliability
- To make troubleshooting stream-specific issues easier by including stream context in logs

*How was it changed?*
- Created LoggedExitRunnable abstract class to:
  - Provide consistent entry/exit logging for async tasks
  - Ensure proper error handling and logging of uncaught exceptions
  - Standardize the task execution pattern
- Modified service callbacks to:
  - Use LoggedExitRunnable for the async operations
  - Include stream name in log messages for better context
  - Move result notifications to finally blocks to ensure they're always called
  - Catch Throwable to handle all error cases and make sure the user is notified
- Enhanced VersionUtil to:
  - Improve error messaging

*What testing was done for the changes?*
- Manually ran the demo application to check the new logs
- CI

Sample new logs (with the file deleted):
```
2025-07-03 23:17:56,725 [KVS-JavaClientExecutor-1] ERROR c.a.k.j.c.KinesisVideoJavaClientFactory - [demo-stream] Kinesis Video service client (DescribeStream) returned an error. Reporting to Kinesis Video PIC.
java.lang.ExceptionInInitializerError: The required resource file: 'pom.properties' was not found!
	at com.amazonaws.kinesisvideo.util.VersionUtil.<clinit>(VersionUtil.java:21)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createClientConfiguration(JavaKinesisVideoServiceClient.java:229)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createAwsKinesisVideoClient(JavaKinesisVideoServiceClient.java:89)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createAmazonKinesisVideoClient(JavaKinesisVideoServiceClient.java:68)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.describeStream(JavaKinesisVideoServiceClient.java:300)
	at com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl$2.execute(DefaultServiceCallbacksImpl.java:252)
	at com.amazonaws.kinesisvideo.util.LoggedExitRunnable.run(LoggedExitRunnable.java:70)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
2025-07-03 23:17:56,851 [KVS-JavaClientExecutor-0] ERROR c.a.k.j.c.KinesisVideoJavaClientFactory - [demo-stream] Kinesis Video service client (DescribeStream) returned an error. Reporting to Kinesis Video PIC.
java.lang.NoClassDefFoundError: Could not initialize class com.amazonaws.kinesisvideo.util.VersionUtil
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createClientConfiguration(JavaKinesisVideoServiceClient.java:229)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createAwsKinesisVideoClient(JavaKinesisVideoServiceClient.java:89)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.createAmazonKinesisVideoClient(JavaKinesisVideoServiceClient.java:68)
	at com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient.describeStream(JavaKinesisVideoServiceClient.java:300)
	at com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl$2.execute(DefaultServiceCallbacksImpl.java:252)
	at com.amazonaws.kinesisvideo.util.LoggedExitRunnable.run(LoggedExitRunnable.java:70)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
