### PR TITLE
Adding stream name context for API calls

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -16,7 +16,7 @@
     </Appenders>
 
     <Loggers>
-        <Root level="WARN">
+        <Root level="DEBUG">
             <AppenderRef ref="ConsoleAppender"/>
             <AppenderRef ref="RollingFile"/>
         </Root>

--- a/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/client/PutMediaClient.java
@@ -76,6 +76,7 @@ public final class PutMediaClient {
         clientBuilder.header(FRAGMENT_TIME_CODE_TYPE_HEADER, mBuilder.mFragmentTimecodeType);
         clientBuilder.completionCallback(mBuilder.mCompletion);
         clientBuilder.setSenderCallback(sender);
+        clientBuilder.setStreamName(mBuilder.mStreamName);
         clientBuilder.setIPVersionFilter(mBuilder.mIPVersionFilter);
         // Timeout if no response is received from the server for put(i.e., acks)
         // Socket will/should be closed by the consumer by throwing the SocketTimeoutException

--- a/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
@@ -4,6 +4,7 @@ import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults;
 import com.amazonaws.kinesisvideo.common.function.Consumer;
 import com.amazonaws.kinesisvideo.socket.SocketFactory;
+import com.amazonaws.kinesisvideo.util.LoggedExitRunnable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -140,17 +141,17 @@ public final class ParallelSimpleHttpClient implements HttpClient {
     private void sendPayloadInBackground() {
         if (mBuilder.mSender != null) {
             payloadSender = Executors.newFixedThreadPool(1);
-            payloadSender.execute(new Runnable() {
+            payloadSender.execute(new LoggedExitRunnable("PutMedia-Sending-" + mBuilder.mStreamName) {
                 @Override
-                public void run() {
+                public void execute() {
                     Exception storedException = null;
                     try {
                         // This is needed to get the thread Id.
-                        log.debug("Start sending data.");
+                        log.debug("[{}] Start sending data.", mBuilder.mStreamName);
                         mBuilder.mSender.accept(mOutputStream);
-                        log.debug("End sending data. Sent all data, close.");
+                        log.debug("[{}] End sending data. Sent all data, close.", mBuilder.mStreamName);
                     } catch (final Exception e) {
-                        log.error("Exception thrown on sending thread", e);
+                        log.error("[{}] Exception thrown on sending thread", mBuilder.mStreamName, e);
                         storedException = e;
                     } finally {
                         //Only call completion if there is an exception, otherwise sender will call completion
@@ -167,16 +168,16 @@ public final class ParallelSimpleHttpClient implements HttpClient {
     private void receiveResponseInBackground() {
         if (mBuilder.mReceiver != null) {
             responseReceiver = Executors.newFixedThreadPool(1);
-            responseReceiver.execute(new Runnable() {
+            responseReceiver.execute(new LoggedExitRunnable("PutMedia-Receiving-" + mBuilder.mStreamName) {
                 @Override
-                public void run() {
+                public void execute() {
                     Exception storedException = null;
                     try {
-                        log.debug("Starting receiving data");
+                        log.debug("[{}] Starting receiving data", mBuilder.mStreamName);
                         mBuilder.mReceiver.accept(mInputStream);
-                        log.debug("Received all data, close");
+                        log.debug("[{}] Received all data, close", mBuilder.mStreamName);
                     } catch (final Exception e) {
-                        log.error("Exception thrown on receiving thread", e);
+                        log.error("[{}] Exception thrown on receiving thread", mBuilder.mStreamName, e);
                         storedException = e;
                     } finally {
                         mBuilder.mCompletion.accept(storedException);
@@ -219,6 +220,7 @@ public final class ParallelSimpleHttpClient implements HttpClient {
         private Integer mTimeout;
         private IPVersionFilter mIPVersionFilter;
         private Consumer<Exception> mCompletion;
+        private String mStreamName = "";
         // TODO: Set to correct output channel
 
         private Builder() {
@@ -269,6 +271,11 @@ public final class ParallelSimpleHttpClient implements HttpClient {
 
         public Builder setIPVersionFilter(final IPVersionFilter ipVersionFilter) {
             mIPVersionFilter = ipVersionFilter;
+            return this;
+        }
+
+        public Builder setStreamName(final String streamName) {
+            mStreamName = streamName;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/java/service/JavaKinesisVideoServiceClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/service/JavaKinesisVideoServiceClient.java
@@ -283,11 +283,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
             createStreamResult = serviceClient.createStream(createStreamRequest);
         } catch (final AmazonClientException e) {
             // Wrap into an KinesisVideoException object
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (CreateStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("create stream result: {}", createStreamResult.toString());
+        log.debug("[{}] create stream result: {}", streamName, createStreamResult.toString());
 
         return createStreamResult.getStreamARN();
     }
@@ -312,7 +312,7 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             describeStreamResult = serviceClient.describeStream(describeStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (DescribeStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
@@ -321,7 +321,7 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
             return null;
         }
 
-        log.debug("describe stream result: {}", describeStreamResult.toString());
+        log.debug("[{}] describe stream result: {}", streamName, describeStreamResult.toString());
         return toStreamDescription(describeStreamResult);
     }
 
@@ -349,11 +349,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             deleteStreamResult = serviceClient.deleteStream(deleteStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (DeleteStream) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("delete stream result: {}", deleteStreamResult.toString());
+        log.debug("[{}] delete stream result: {}", streamName, deleteStreamResult.toString());
     }
 
     @Override
@@ -378,11 +378,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             tagStreamResult = serviceClient.tagStream(tagStreamRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (TagStream) failed.", streamArn, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("tag resource result: {}", tagStreamResult.toString());
+        log.debug("[{}] tag resource result: {}", streamArn, tagStreamResult.toString());
     }
 
     @Override
@@ -408,11 +408,11 @@ public final class JavaKinesisVideoServiceClient implements KinesisVideoServiceC
         try {
             getDataEndpointResult = serviceClient.getDataEndpoint(getDataEndpointRequest);
         } catch (final AmazonClientException e) {
-            log.error("Service call failed.", e);
+            log.error("[{}] Service call (GetDataEndpoint) failed.", streamName, e);
             throw new KinesisVideoException(e);
         }
 
-        log.debug("get data endpoint result: {}", getDataEndpointResult.toString());
+        log.debug("[{}] get data endpoint result: {}", streamName, getDataEndpointResult.toString());
 
         return getDataEndpointResult.getDataEndpoint();
     }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Adding the stream name for API calls

*Why was it changed?*
- Makes it easier to keep track in multi-stream scenarios

*How was it changed?*
- Added the Enters and Leaves log for both PutMedia sender and receiver threads
- Added the stream name to the API calls (service callbacks)

*What testing was done for the changes?*
- Ran DemoAppMain locally to check the new logs
- CI

Example of the new logs:
```
2025-07-04 00:04:10,176 [KVS-JavaClientExecutor-1] DEBUG c.a.k.u.LoggedExitRunnable - [PutMedia-demo-stream] Enter
...
2025-07-04 00:04:10,427 [pool-4-thread-1] DEBUG c.a.k.u.LoggedExitRunnable - [PutMedia-Sending-demo-stream] Enter
2025-07-04 00:04:10,427 [pool-4-thread-1] DEBUG c.a.k.h.ParallelSimpleHttpClient - [demo-stream] Start sending data.
2025-07-04 00:04:10,427 [pool-4-thread-1] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - no data for stream demo-stream with uploadHandle 0, waiting
2025-07-04 00:04:10,428 [pool-5-thread-1] DEBUG c.a.k.u.LoggedExitRunnable - [PutMedia-Receiving-demo-stream] Enter
2025-07-04 00:04:10,428 [pool-5-thread-1] DEBUG c.a.k.h.ParallelSimpleHttpClient - [demo-stream] Starting receiving data
...
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_stopKinesisVideoStream(): Stopping Kinesis Video stream.
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - stopKinesisVideoStream(): Stopping Kinesis Video Stream 000000015a0daa30.
2025-07-04 00:04:20,314 [pool-4-thread-1] DEBUG c.a.k.h.ParallelSimpleHttpClient - [demo-stream] End sending data. Sent all data, close.
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Data availability notification. Upload handle: 0, Size: 0, Duration 0 
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_stopKinesisVideoStream(): Stopping Kinesis Video stream.
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - stopKinesisVideoStream(): Stopping Kinesis Video Stream 000000015a0daa30.
2025-07-04 00:04:20,314 [pool-4-thread-1] DEBUG c.a.k.u.LoggedExitRunnable - [PutMedia-Sending-demo-stream] Leave
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Data availability notification. Upload handle: 0, Size: 0, Duration 0 
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Stream demo-stream is closed
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Data availability notification. Upload handle: 0, Size: 0, Duration 0 
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoStream(): Stopping Kinesis Video stream.
2025-07-04 00:04:20,314 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoStream(): Freeing Kinesis Video stream.
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] Stream - freeStream(): [demo-stream] Freeing stream
2025-07-04 00:04:20,314 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] Stream - freeStream(): [demo-stream] Completed freeing stream
2025-07-04 00:04:20,315 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_stopKinesisVideoStreams(): Stopping Kinesis Video streams.
2025-07-04 00:04:20,315 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - stopKinesisVideoStreams(): Stopping Kinesis Video Streams.
2025-07-04 00:04:20,315 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoProducerJNI - Java_com_amazonaws_kinesisvideo_internal_producer_jni_NativeKinesisVideoProducerJni_freeKinesisVideoClient(): Freeing Kinesis Video client.
2025-07-04 00:04:20,315 [main] INFO  c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClient(): Freeing Kinesis Video Client
2025-07-04 00:04:20,315 [main] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - [PIC] KinesisVideoClient - freeKinesisVideoClientInternal(): Total allocated memory 0
2025-07-04 00:04:23,336 [pool-5-thread-1] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Received end-of-stream for ACKs.
2025-07-04 00:04:23,336 [pool-5-thread-1] DEBUG c.a.k.j.c.KinesisVideoJavaClientFactory - Finished reading ACKs stream
2025-07-04 00:04:23,336 [pool-5-thread-1] DEBUG c.a.k.h.ParallelSimpleHttpClient - [demo-stream] Received all data, close
2025-07-04 00:04:23,337 [pool-5-thread-1] DEBUG c.a.k.u.LoggedExitRunnable - [PutMedia-Receiving-demo-stream] Leave
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.