### PR TITLE
Making KinesisVideoFrame immutable and threadsafe

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
@@ -1,138 +1,176 @@
 package com.amazonaws.kinesisvideo.producer;
 
-import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_TRACK_ID;
-import static java.util.Objects.requireNonNull;
-
-import java.nio.ByteBuffer;
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import com.amazonaws.kinesisvideo.util.StreamInfoConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.nio.ByteBuffer;
+
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_TRACK_ID;
 
 /**
  * Kinesis Video frame representation.
+ * <p>NOTE: This class must match the Frame declaration in native code in
+ * /mkvgen/Include.h</p>
  *
- * NOTE: This class must match the Frame declaration in native code in
- * /mkvgen/Include.h
+ * @see <a href="https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/master/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h">PIC's MKVGEN</a>
  */
-
+@Immutable
+@ThreadSafe
 public class KinesisVideoFrame {
+
+    private static final Logger log = LogManager.getLogger(KinesisVideoFrame.class);
+
     /**
      * Current version for the structure as defined in the native code
      */
     public static final int FRAME_CURRENT_VERSION = 0;
 
+    public static final int FRAME_VERSION_ZERO = 0;
+
     /**
      * Version of frame structure
      */
-    private final int mVersion;
+    private final int version;
 
     /**
      * Index of the frame
      */
-    private final int mIndex;
+    private final int index;
 
     /**
      * Frame flags
      */
-    private final int mFlags;
+    private final int flags;
 
     /**
      * The decoding timestamp of the frame in 100ns precision
      */
-    private final long mDecodingTs;
+    private final long decodingTs;
 
     /**
      * The presentation timestamp of the frame in 100ns precision
      */
-    private final long mPresentationTs;
+    private final long presentationTs;
 
     /**
      * The duration of the frame in 100ns precision
      */
-    private final long mDuration;
+    private final long duration;
 
     /**
      * The track id of the frame
      */
-    private final long mTrackId;
+    private final long trackId;
 
     /**
      * The actual frame data
      */
-    private final ByteBuffer mData;
-    private final int mSize;
+    @Nonnull
+    private final ByteBuffer data;
 
-    public KinesisVideoFrame(int index, int flags, long decodingTs, long presentationTs, long duration,
-            @Nonnull ByteBuffer data, long trackId) {
-        mVersion = FRAME_CURRENT_VERSION;
-        mIndex = index;
-        mFlags = flags;
-        mDecodingTs = decodingTs;
-        mPresentationTs = presentationTs;
-        mDuration = duration;
-        mData = requireNonNull(data);
-        mTrackId = trackId;
-        mSize = data.remaining();
+    /**
+     * Creates a V{@value #FRAME_VERSION_ZERO} struct version of a KinesisVideoFrame. Submit these frames to a Stream using
+     * {@link com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream#putFrame(KinesisVideoFrame)}
+     *
+     * @param index          ID for this frame.
+     * @param flags          Flags associated with this frame. They should be bitwise OR'ed together
+     *                       when specifying more than 1. See {@link FrameFlags}.
+     * @param decodingTs     DTS of this frame in hundreds of nanosecond units.
+     * @param presentationTs PTS of this frame in hundreds of nanosecond units.
+     * @param duration       Duration of this frame in hundreds of nanosecond units. Can be 0.
+     * @param data           The frame contents.
+     * @param trackId        The track number this frame belongs to.
+     * @throws OutOfMemoryError if not enough memory to create a copy of the data.
+     */
+    public KinesisVideoFrame(final int index, final int flags, final long decodingTs, final long presentationTs,
+                             final long duration, @Nonnull final ByteBuffer data, final long trackId) {
+
+        Preconditions.checkNotNull(data, "Null data was passed in!");
+
+        this.version = FRAME_VERSION_ZERO;
+        this.index = index;
+        this.flags = flags;
+        this.decodingTs = decodingTs;
+        this.presentationTs = presentationTs;
+        this.duration = duration;
+        this.trackId = trackId;
+
+        // Make a copy of the content as to be truly immutable
+        try {
+            final ByteBuffer temp = ByteBuffer.allocateDirect(data.remaining());
+            temp.put(data.duplicate());
+            temp.flip();
+            this.data = temp.asReadOnlyBuffer();
+        } catch (final OutOfMemoryError err) {
+            log.error("Ran out of memory while creating the frame with size: {}!", data.remaining(), err);
+            throw err;
+        }
     }
 
-    public KinesisVideoFrame(int index, int flags, long decodingTs, long presentationTs, long duration,
-                             @Nonnull ByteBuffer data) {
+    /**
+     * Creates a Kinesis Video Frame V0 with trackId = {@value StreamInfoConstants#DEFAULT_TRACK_ID}.
+     * See {@link #KinesisVideoFrame(int, int, long, long, long, ByteBuffer, long)}
+     */
+    public KinesisVideoFrame(final int index, final int flags, final long decodingTs, final long presentationTs,
+                             final long duration, @Nonnull final ByteBuffer data) {
         this(index, flags, decodingTs, presentationTs, duration, data, DEFAULT_TRACK_ID);
     }
 
     public int getIndex() {
-        return mIndex;
+        return this.index;
     }
 
     public int getFlags() {
-        return mFlags;
+        return this.flags;
     }
 
     public long getDecodingTs() {
-        return mDecodingTs;
+        return this.decodingTs;
     }
 
     public long getPresentationTs() {
-        return mPresentationTs;
+        return this.presentationTs;
     }
 
     public long getDuration() {
-        return mDuration;
+        return this.duration;
     }
 
     public int getSize() {
-        return mSize;
+        return this.data.capacity();
     }
 
+    /**
+     * Native code will access this buffer via {@code GetDirectBufferAddress()}.
+     * See {@code setFrame} in the JNI.
+     *
+     * @return a read-only ByteBuffer containing this frame's data.
+     */
     @Nonnull
     public ByteBuffer getData() {
-        ByteBuffer byteBuffer = mData;
-        try {
-            if (mData.hasArray()) {
-                byteBuffer = ByteBuffer.allocateDirect(mSize);
-                byteBuffer.put(mData);
-                mData.rewind();
-                byteBuffer.flip();
-            }
-        } catch(final Exception e) {
-            // Some Android implementations throw when accessing hasArray() API. We will ignore it
-        }
-
-        return byteBuffer;
+        // Don't return mData directly to make sure each caller gets its own set of position/limit pointers.
+        return this.data.duplicate();
     }
 
     public long getTrackId() {
-        return mTrackId;
+        return this.trackId;
     }
 
-    @Override public String toString() {
-        return new StringBuilder().append(getClass().getSimpleName()).append("{").append("mIndex=").append(mIndex)
-                .append(", mFlags=").append(mFlags).append(", mDecodingTs=").append(mDecodingTs)
-                .append(", mPresentationTs=").append(mPresentationTs).append(", mDuration=").append(mDuration)
-                .append(", mData=").append(mData).append(", mTrackId=").append(mTrackId).append("}")
+    @Override
+    public String toString() {
+        return new StringBuilder().append(getClass().getSimpleName()).append("{").append("index=").append(this.index)
+                .append(", flags=").append(this.flags).append(", decodingTs=").append(this.decodingTs)
+                .append(", presentationTs=").append(this.presentationTs).append(", duration=").append(this.duration)
+                .append(", data=").append(this.data).append(", trackId=").append(this.trackId).append("}")
                 .toString();
     }
 
     public int getVersion() {
-        return mVersion;
+        return this.version;
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrame.java
@@ -80,8 +80,8 @@ public class KinesisVideoFrame {
      * @param index          ID for this frame.
      * @param flags          Flags associated with this frame. They should be bitwise OR'ed together
      *                       when specifying more than 1. See {@link FrameFlags}.
-     * @param decodingTs     DTS of this frame in hundreds of nanosecond units.
-     * @param presentationTs PTS of this frame in hundreds of nanosecond units.
+     * @param decodingTs     DTS of this frame in hundreds of nanosecond units. Should be monotonically increasing.
+     * @param presentationTs PTS of this frame in hundreds of nanosecond units. Should be monotonically increasing.
      * @param duration       Duration of this frame in hundreds of nanosecond units. Can be 0.
      * @param data           The frame contents.
      * @param trackId        The track number this frame belongs to.
@@ -90,7 +90,7 @@ public class KinesisVideoFrame {
     public KinesisVideoFrame(final int index, final int flags, final long decodingTs, final long presentationTs,
                              final long duration, @Nonnull final ByteBuffer data, final long trackId) {
 
-        Preconditions.checkNotNull(data, "Null data was passed in!");
+        Preconditions.checkNotNull(data, "Frame data can't be null");
 
         this.version = FRAME_VERSION_ZERO;
         this.index = index;
@@ -153,7 +153,7 @@ public class KinesisVideoFrame {
      */
     @Nonnull
     public ByteBuffer getData() {
-        // Don't return mData directly to make sure each caller gets its own set of position/limit pointers.
+        // Don't return data directly to make sure each caller gets its own set of position/limit pointers.
         return this.data.duplicate();
     }
 

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrameTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrameTest.java
@@ -201,10 +201,10 @@ public class KinesisVideoFrameTest {
     }
 
     @Test
-    public void whenEmptyDataProvided_thenNoExceptionIsThrown() {
+    public void whenEmptyBufferProvided_thenNoExceptionIsThrown() {
         final ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
 
-        // Attempt to create a frame with empty data
+        // Attempt to create a frame with 0 size data
         // Main use case is for submitting end of fragment
         createTestFrameFromBuffer(emptyBuffer);
     }

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrameTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFrameTest.java
@@ -1,0 +1,211 @@
+package com.amazonaws.kinesisvideo.producer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.amazonaws.kinesisvideo.producer.FrameFlags.FRAME_FLAG_KEY_FRAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KinesisVideoFrameTest {
+
+    private static final Logger log = LogManager.getLogger(KinesisVideoFrameTest.class);
+
+    private static final int FRAME_INDEX = 42;
+    private static final int FRAME_FLAGS = FRAME_FLAG_KEY_FRAME;
+    private static final long DECODING_TS = 1000L;
+    private static final long PRESENTATION_TS = 1005L;
+    private static final long DURATION = 100L;
+    private static final long TRACK_ID = 1L;
+    private static final int BUFFER_SIZE = 1024;
+
+    private KinesisVideoFrame createTestFrameFromBuffer(final ByteBuffer data) {
+        return new KinesisVideoFrame(
+                FRAME_INDEX,
+                FRAME_FLAGS,
+                DECODING_TS,
+                PRESENTATION_TS,
+                DURATION,
+                data,
+                TRACK_ID
+        );
+    }
+
+    @Test
+    public void whenFrameIsCreated_thenGettersReturnCorrectValues() {
+        final byte[] data = new byte[BUFFER_SIZE];
+        final ByteBuffer testData = ByteBuffer.wrap(data);
+
+        final KinesisVideoFrame frame = createTestFrameFromBuffer(testData);
+
+        assertEquals(FRAME_INDEX, frame.getIndex());
+        assertEquals(FRAME_FLAGS, frame.getFlags());
+        assertEquals(DECODING_TS, frame.getDecodingTs());
+        assertEquals(PRESENTATION_TS, frame.getPresentationTs());
+        assertEquals(DURATION, frame.getDuration());
+        assertEquals(TRACK_ID, frame.getTrackId());
+        assertEquals(BUFFER_SIZE, frame.getSize());
+        assertEquals(KinesisVideoFrame.FRAME_CURRENT_VERSION, frame.getVersion());
+
+        final ByteBuffer receivedData = frame.getData();
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            assertEquals(data[i], receivedData.get(i));
+        }
+    }
+
+    @Test
+    // Verify immutability
+    public void whenOriginalDataIsModified_thenFrameDataRemainsUnchanged() {
+        // Create a test buffer with backing array
+        final byte[] originalArray = new byte[BUFFER_SIZE];
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            originalArray[i] = (byte) i;
+        }
+        final ByteBuffer testData = ByteBuffer.wrap(originalArray);
+
+        final KinesisVideoFrame frame = createTestFrameFromBuffer(testData);
+
+        // Get the data and verify it matches the original
+        final ByteBuffer frameData = frame.getData();
+        assertEquals(BUFFER_SIZE, frameData.remaining());
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            assertEquals((byte) i, frameData.get());
+        }
+
+        // Modify the original array
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            originalArray[i] = (byte) (i + 100);
+        }
+
+        // Get the data again and verify it's unchanged
+        final ByteBuffer frameData2 = frame.getData();
+        assertEquals(BUFFER_SIZE, frameData2.remaining());
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            assertEquals((byte) i, frameData2.get());
+        }
+    }
+
+    @Test(expected = ReadOnlyBufferException.class)
+    public void whenModifyingReturnedBuffer_thenReadOnlyExceptionIsThrown() {
+        final ByteBuffer testData = ByteBuffer.wrap(new byte[]{1, 2, 3, 4,});
+
+        final KinesisVideoFrame frame = createTestFrameFromBuffer(testData);
+
+        final ByteBuffer frameData = frame.getData();
+        assertTrue(frameData.isReadOnly());
+
+        // Attempt to modify the buffer should throw ReadOnlyBufferException
+        frameData.put(0, (byte) 99);
+        fail("Expected ReadOnlyBufferException was not thrown");
+    }
+
+    @Test
+    public void whenMultipleThreadsAccessData_thenNoDataCorruptionOccurs() throws InterruptedException {
+        final ByteBuffer testData = ByteBuffer.allocate(BUFFER_SIZE);
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            testData.put((byte) i);
+        }
+        testData.flip();
+
+        final KinesisVideoFrame frame = createTestFrameFromBuffer(testData);
+
+        // Thead parameters
+        final int threadCount = 50;
+        final int iterationsPerThread = 1000;
+
+        // Using a latch to ensure all threads start at roughly the same time
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch completionLatch = new CountDownLatch(threadCount);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int t = 0; t < threadCount; t++) {
+            executor.submit(() -> {
+                try {
+                    // Wait for the signal to start
+                    startLatch.await();
+
+                    // Each thread gets the data and verifies it multiple times
+                    for (int i = 0; i < iterationsPerThread; i++) {
+                        final ByteBuffer data = frame.getData();
+
+                        // Verify the data
+                        assertEquals(BUFFER_SIZE, data.remaining());
+
+                        // Read and verify some bytes
+                        for (int j = 0; j < BUFFER_SIZE; j++) {
+                            if (data.get() != (byte) j) {
+                                testFailed.set(true);
+                                break;
+                            }
+                        }
+
+                        // Modify the position and limit to ensure thread isolation
+                        data.position(0);
+                        data.limit(data.capacity() / 2);
+                    }
+                } catch (final Throwable thr) {
+                    log.error("Encountered an issue in a thread!", thr);
+                    testFailed.set(true);
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        assertTrue("Threads did not complete in time", completionLatch.await(30, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        // Check if any thread reported a failure
+        assertFalse("Thread safety test failed, check the logs for more information", testFailed.get());
+    }
+
+    @Test
+    public void whenPositionChangedInOneBuffer_thenOtherBuffersAreUnaffected() {
+        final ByteBuffer testData = ByteBuffer.allocateDirect(BUFFER_SIZE);
+
+        final KinesisVideoFrame frame = createTestFrameFromBuffer(testData);
+
+        // Get two buffers from the same frame
+        final ByteBuffer buffer1 = frame.getData();
+        final ByteBuffer buffer2 = frame.getData();
+
+        // Modify position of first buffer
+        buffer1.position(2);
+
+        // Verify second buffer is unaffected
+        assertEquals(0, buffer2.position());
+        assertEquals(BUFFER_SIZE, buffer2.remaining());
+    }
+
+    @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions") // Deliberately passing null to test exception
+    public void whenNullDataProvided_thenNullPointerExceptionIsThrown() {
+        // Attempt to create a frame with null data
+        createTestFrameFromBuffer(null);
+    }
+
+    @Test
+    public void whenEmptyDataProvided_thenNoExceptionIsThrown() {
+        final ByteBuffer emptyBuffer = ByteBuffer.allocate(0);
+
+        // Attempt to create a frame with empty data
+        // Main use case is for submitting end of fragment
+        createTestFrameFromBuffer(emptyBuffer);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Refactored the `KinesisVideoFrame` class to ensure true immutability and thread safety
- Added unit tests to verify thread safety and immutability guarantees
- Improved code style and documentation

*Why was it changed?*
- The class was intended to be immutable, but the implementation didn't fully enforce this property
- The previous implementation had thread safety issues where concurrent calls to `getData()` could interfere with each other due to shared buffer position state
- We received a report of `getData()` occasionally returning a buffer with all zeros but the correct size when called from multiple threads
- The previous implementation inefficiently created a new direct ByteBuffer on every `getData()` call, potentially causing additional memory pressure

> [!NOTE]
> We received a report that a segmentation fault could occur when `ByteBuffer.allocateDirect` failed due to out-of-memory conditions, since the JNI code which calls `GetDirectBufferAddress()`, would return `NULL`. That will be covered in a subsequent PR (not in this one).

*How was it changed?*
- Modified the constructor to create a direct ByteBuffer copy of the input data once during initialization
- Made the stored buffer read-only using `asReadOnlyBuffer()` to enforce immutability
- Updated `getData()` to return a duplicate of the stored buffer to ensure thread safety
- Added proper error handling for `OutOfMemoryError` during buffer allocation
- Added explicit `@Immutable` and `@ThreadSafe` annotations to document the design intent
- Added additional logging for error conditions
- Added precondition checks to validate input parameters
- Improved field naming by removing Hungarian notation prefixes (m)
- Enhanced JavaDoc documentation to clarify usage and behavior

*What testing was done for the changes?*
- Created a comprehensive test suite that verifies:
  - Thread safety with concurrent access from multiple threads
  - True immutability when original data is modified
  - Position independence between buffers returned by `getData()`
  - Read-only protection of returned buffers
  - Proper exception handling for null input data
- Stress-tested with 50 concurrent threads to ensure the "all zeros" buffer issue is resolved


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
