### PR TITLE
Fix: OutOfMemoryError null crash with KinesisVideoFrame.getData() and NAL_ADAPTATION_ANNEXB_NALS

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,6 +18,9 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      JAVA_LIBRARY_PATH: src/main/resources/lib/ubuntu/
+
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -28,6 +31,15 @@ jobs:
           java-version: 11
           distribution: 'adopt'
 
+      - name: Build JNI (develop branch) # When merging to master, we use the JNI that is committed
+        if: ${{ github.ref == 'refs/heads/develop' || github.base_ref == 'develop' }}
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j
+          echo "JAVA_LIBRARY_PATH=build" >> $GITHUB_ENV
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -36,11 +48,12 @@ jobs:
 
       - name: Run tests
         run: |
+          echo "Using -Djava.library.path=${JAVA_LIBRARY_PATH}"
           mvn clean verify -DargLine="\
             -Daws.accessKeyId=${AWS_ACCESS_KEY_ID} \
             -Daws.secretKey=${AWS_SECRET_ACCESS_KEY} \
             -Daws.sessionToken=${AWS_SESSION_TOKEN} \
-            -Djava.library.path=src/main/resources/lib/ubuntu/ \
+            -Djava.library.path=${JAVA_LIBRARY_PATH} \
             -Dlog4j.configurationFile=log4j2.xml"
         shell: bash
 

--- a/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -382,6 +382,7 @@ void KinesisVideoClientWrapper::putKinesisVideoFrame(jlong streamHandle, jobject
         throwNativeException(env, EXCEPTION_NAME, "Failed converting frame object.", STATUS_INVALID_OPERATION);
         return;
     }
+    // setFrame ensures that frame.frameData != NULL
 
     PStreamInfo pStreamInfo;
     UINT32 zeroCount = 0;
@@ -587,7 +588,7 @@ void KinesisVideoClientWrapper::kinesisVideoStreamFragmentAck(jlong streamHandle
     // Convert the KinesisVideoFrame object
     if (!setFragmentAck(env, fragmentAck, &ack))
     {
-        DLOGE("Failed converting frame object.");
+        DLOGE("Failed converting fragment ack object.");
         throwNativeException(env, EXCEPTION_NAME, "Failed converting fragment ack object.", STATUS_INVALID_OPERATION);
         return;
     }

--- a/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -842,7 +842,9 @@ BOOL setFrame(JNIEnv* env, jobject kinesisVideoFrame, PFrame pFrame)
     } else {
         jobject byteBuffer = (jstring) env->CallObjectMethod(kinesisVideoFrame, methodId);
         CHK_JVM_EXCEPTION(env);
-        pFrame->frameData = (PBYTE) env->GetDirectBufferAddress(byteBuffer);
+        PBYTE frameData = (PBYTE) env->GetDirectBufferAddress(byteBuffer);
+        CHK_ERR(frameData != NULL, STATUS_INVALID_ARG, "ByteBuffer has NULL data!");
+        pFrame->frameData = frameData;
     }
 
 CleanUp:

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +15,8 @@ import com.amazonaws.kinesisvideo.producer.Time;
 import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
 import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
 import com.amazonaws.kinesisvideo.producer.ProducerException;
+
+import javax.annotation.Nonnull;
 
 public class ProducerApiTest extends ProducerTestBase{
 

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
@@ -181,21 +181,20 @@ public class ProducerTestBase {
      */
     protected KinesisVideoProducerStream createTestStream(String streamName, StreamInfo.StreamingType streamingType,
                                                           long maxLatency, long bufferDuration) {
+        return createTestStream(streamName, streamingType, maxLatency, bufferDuration, NAL_ADAPTATION_FLAG_NONE);
+    }
+
+    protected KinesisVideoProducerStream createTestStream(String streamName, StreamInfo.StreamingType streamingType,
+                                                          long maxLatency, long bufferDuration, StreamInfo.NalAdaptationFlags nalAdaptationFlags) {
         KinesisVideoProducerStream kinesisVideoProducerStream = null;
-        final byte[] AVCC_EXTRA_DATA = {
-                (byte) 0x01, (byte) 0x42, (byte) 0x00, (byte) 0x1E, (byte) 0xFF, (byte) 0xE1, (byte) 0x00, (byte) 0x22,
-                (byte) 0x27, (byte) 0x42, (byte) 0x00, (byte) 0x1E, (byte) 0x89, (byte) 0x8B, (byte) 0x60, (byte) 0x50,
-                (byte) 0x1E, (byte) 0xD8, (byte) 0x08, (byte) 0x80, (byte) 0x00, (byte) 0x13, (byte) 0x88,
-                (byte) 0x00, (byte) 0x03, (byte) 0xD0, (byte) 0x90, (byte) 0x70, (byte) 0x30, (byte) 0x00, (byte) 0x5D,
-                (byte) 0xC0, (byte) 0x00, (byte) 0x17, (byte) 0x70, (byte) 0x5E, (byte) 0xF7, (byte) 0xC1, (byte) 0xF0,
-                (byte) 0x88, (byte) 0x46, (byte) 0xE0, (byte) 0x01, (byte) 0x00, (byte) 0x04, (byte) 0x28, (byte) 0xCE,
-                (byte) 0x1F, (byte) 0x20};
+        
+        final byte[] codecPrivateData = ProducerTestCPDs.getTestCPD(nalAdaptationFlags);
 
         final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
         final String finalStreamName = prefix + streamName;
         prepareStream(finalStreamName);
 
-        StreamInfo streamInfo = new StreamInfo(
+        final StreamInfo streamInfo = new StreamInfo(
                 StreamInfo.STREAM_INFO_CURRENT_VERSION,
                 finalStreamName,
                 streamingType,
@@ -219,19 +218,19 @@ public class ProducerTestBase {
                 DEFAULT_STALENESS_DURATION,
                 DEFAULT_TIMESCALE,
                 RECALCULATE_METRICS,
-                AVCC_EXTRA_DATA,
+                codecPrivateData,
                 new Tag[]{
                         new Tag("device", "Test Device"),
                         new Tag("stream", "Test Stream")},
-                NAL_ADAPTATION_FLAG_NONE,
+                nalAdaptationFlags,
                 allowStreamCreation
         );
 
         try {
             kinesisVideoProducerStream = kinesisVideoProducer.createStreamSync(streamInfo, streamCallbacks);
 
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (final Exception e) {
+            log.error("Failed to create the stream: {}", finalStreamName, e);
             fail();
         }
         return kinesisVideoProducerStream;

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestCPDs.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestCPDs.java
@@ -1,0 +1,51 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+
+import java.util.Arrays;
+
+/**
+ * Utility class with some pre-defined CPDs used for the Stream creation.
+ */
+public final class ProducerTestCPDs {
+    private ProducerTestCPDs() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * AVCC format codec private data
+     */
+    public static final byte[] AVCC_EXTRA_DATA = {
+            (byte) 0x01, (byte) 0x42, (byte) 0x00, (byte) 0x1E, (byte) 0xFF, (byte) 0xE1, (byte) 0x00, (byte) 0x22,
+            (byte) 0x27, (byte) 0x42, (byte) 0x00, (byte) 0x1E, (byte) 0x89, (byte) 0x8B, (byte) 0x60, (byte) 0x50,
+            (byte) 0x1E, (byte) 0xD8, (byte) 0x08, (byte) 0x80, (byte) 0x00, (byte) 0x13, (byte) 0x88,
+            (byte) 0x00, (byte) 0x03, (byte) 0xD0, (byte) 0x90, (byte) 0x70, (byte) 0x30, (byte) 0x00, (byte) 0x5D,
+            (byte) 0xC0, (byte) 0x00, (byte) 0x17, (byte) 0x70, (byte) 0x5E, (byte) 0xF7, (byte) 0xC1, (byte) 0xF0,
+            (byte) 0x88, (byte) 0x46, (byte) 0xE0, (byte) 0x01, (byte) 0x00, (byte) 0x04, (byte) 0x28, (byte) 0xCE,
+            (byte) 0x1F, (byte) 0x20};
+
+    /**
+     * Annex-B format codec private data (NAL units with start codes).
+     */
+    public static final byte[] ANNEXB_EXTRA_DATA = {
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x67, (byte) 0x42, (byte) 0x00, (byte) 0x1E,
+            (byte) 0x89, (byte) 0x8B, (byte) 0x60, (byte) 0x50, (byte) 0x1E, (byte) 0xD8, (byte) 0x08, (byte) 0x80,
+            (byte) 0x00, (byte) 0x13, (byte) 0x88, (byte) 0x00, (byte) 0x03, (byte) 0xD0, (byte) 0x90, (byte) 0x70,
+            (byte) 0x30, (byte) 0x00, (byte) 0x5D, (byte) 0xC0, (byte) 0x00, (byte) 0x17, (byte) 0x70, (byte) 0x5E,
+            (byte) 0xF7, (byte) 0xC1, (byte) 0xF0, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01, (byte) 0x68,
+            (byte) 0xCE, (byte) 0x1F, (byte) 0x20
+    };
+
+    /**
+     * Select the appropriate CPD based on the NAL adaptation flag
+     */
+    public static byte[] getTestCPD(final StreamInfo.NalAdaptationFlags nalAdaptationFlags) {
+        if (nalAdaptationFlags == StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_AVCC_NALS ||
+                nalAdaptationFlags == StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_ANNEXB_CPD_NALS ||
+                nalAdaptationFlags == StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_ANNEXB_CPD_AND_FRAME_NALS) {
+            return Arrays.copyOf(ProducerTestCPDs.ANNEXB_EXTRA_DATA, ProducerTestCPDs.ANNEXB_EXTRA_DATA.length);
+        } else {
+            return Arrays.copyOf(ProducerTestCPDs.AVCC_EXTRA_DATA, ProducerTestCPDs.AVCC_EXTRA_DATA.length);
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/common/PutFrameNalAdaptionFlagsTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/PutFrameNalAdaptionFlagsTest.java
@@ -1,0 +1,104 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Time;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests check that putFrame with a non-direct ByteBuffer is OK.
+ * The JNI layer will grab the frame data using GetDirectBufferAddress, but it may perform additional logic
+ * on the frameData based on the Stream's NAL adaption flags.
+ *
+ * <p>See setFrame() and putKinesisVideoFrame() in the JNI</p>
+ */
+@RunWith(Parameterized.class)
+public class PutFrameNalAdaptionFlagsTest extends ProducerTestBase {
+
+    @Before
+    public void checkJNIAvailability() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+    }
+
+    @Parameterized.Parameters(name = "{index}: NalAdaptionFlag={0}")
+    public static Collection<Object[]> parametersFor_when_putFrameWithNullByteBufferData_then_exceptionIsThrown() {
+        return Arrays.stream(StreamInfo.NalAdaptationFlags.values())
+                .map(nalAdaptationFlag -> new Object[]{nalAdaptationFlag})
+                .collect(Collectors.toList());
+    }
+
+    private final StreamInfo.NalAdaptationFlags nalAdaptationFlags;
+
+    public PutFrameNalAdaptionFlagsTest(final StreamInfo.NalAdaptationFlags nalAdaptationFlag) {
+        this.nalAdaptationFlags = nalAdaptationFlag;
+    }
+
+    /**
+     * This test verifies that a ProducerException is thrown when attempting to put a frame with a null ByteBuffer data
+     * using all the NAL adaption flags.
+     *
+     * <p>The JNI has a special case with {@link com.amazonaws.kinesisvideo.producer.StreamInfo.NalAdaptationFlags#NAL_ADAPTATION_ANNEXB_CPD_NALS}</p>
+     *
+     * <p>See KinesisVideoClientWrapper.cpp in the JNI.</p>
+     */
+    @Test
+    public void when_putFrameWithNullByteBufferData_then_exceptionIsThrown() {
+        final KinesisVideoProducerStream kinesisVideoProducerStream;
+        final String testStreamName = "JavaProducerApiTestStream_when_putFrameWithNullByteBufferData_then_exceptionIsThrown";
+
+        createProducer();
+
+        // Create a test stream with the appropriate NAL adaptation flag
+        kinesisVideoProducerStream = createTestStream(testStreamName,
+                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME, TEST_LATENCY, TEST_BUFFER_DURATION, this.nalAdaptationFlags);
+
+        // Create a non-direct ByteBuffer which will cause JNI to return null when calling GetDirectBufferAddress
+        final ByteBuffer nonDirectBuffer = ByteBuffer.allocate(10);
+
+        final long currentTimeMs = System.currentTimeMillis() * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        final KinesisVideoFrame frame = new KinesisVideoFrame(
+                0,
+                FRAME_FLAG_KEY_FRAME,
+                currentTimeMs,
+                currentTimeMs,
+                this.frameDuration_,
+                nonDirectBuffer) {
+
+            // Override getData() to return our non-direct buffer directly without the conversion logic
+            // that's in the original implementation
+            @Override
+            @Nonnull
+            public ByteBuffer getData() {
+                return nonDirectBuffer;
+            }
+        };
+
+        try {
+            // This should throw an exception due to the null safety check in JNI
+            kinesisVideoProducerStream.putFrame(frame);
+            fail("Expected ProducerException to be thrown when using a ByteBuffer that returns null address");
+        } catch (final ProducerException e) {
+            // Expected exception
+            assertEquals(ProducerException.STATUS_INVALID_OPERATION, e.getStatusCode());
+        } finally {
+            freeTestStream(kinesisVideoProducerStream);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
- See also: #230

*What was changed?*
- Added a null check before accessing the ByteBuffer data in the JNI
- Enhanced error handling and logging
- Added comprehensive test coverage for all NAL adaptation flags with appropriate codec private data
- Created a utility class for managing test codec private data formats

*Why was it changed?*
- `KinesisVideoFrame.getData()` is supposed to return a copy of the data. When it goes to allocate the copy, it could return the original heap-backed buffer when it's out of memory, which would result in a segfault when passed to native code. `GetDirectBufferAddress` returns `NULL` in the JNI when the `ByteBuffer` is not a direct buffer (heap-backed buffer).
- Since the buffer returned a valid size, there was a mismatch since the data array pointer is actually NULL, which caused a null dereference when the JNI goes to adjust the frame based on the NAL adaptation flags.
- NAL adaptation flags requires codec private data format (AVCC or Annex-B) for the stream to be created successfully.

> [!NOTE]
> I observed the issue only when using `NAL_ADAPTATION_ANNEXB_NALS` flag. With the other flags, the MKV generator (via `::putKinesisVideoFrame`) will return [0x32000001 - STATUS_MKV_INVALID_FRAME_DATA](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/mkvgen/src/MkvGenerator.c#L873) and correctly return an error to the `putFrame` caller.

*How was it changed?*
- Added null pointer validation in the JNI layer's setFrame method to prevent crashes when GetDirectBufferAddress returns NULL
- Added a parameterized test that verifies proper error handling for all NAL adaptation flags with the non-direct ByteBuffer
- Created a ProducerTestCPDs utility class to centralize codec private data management
- Enhanced ProducerTestBase to select appropriate CPD based on NAL adaptation flags
- Improved error messages and logging for better diagnostics

*What testing was done for the changes?*
- Added a comprehensive parameterized test that covers all NAL adaptation flags with the non-direct ByteBuffer
- The new tests pass locally with both AVCC and Annex-B format codec private data
- Ran the demoApp and checked playback in the AWS management console

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
