### PR TITLE
Deprecate mutable constant, defensive copies of Date, thread safety tests

### DIFF
--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppCachedInfo.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.demoapp.auth.AuthHelper;
-import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsProviderImpl;
 import com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory;
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSource;
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSourceConfiguration;
@@ -76,7 +75,7 @@ public final class DemoAppCachedInfo {
             final AWSCredentialsProvider awsCredentialsProvider = AuthHelper.getSystemPropertiesCredentialsProvider();
             final KinesisVideoClientConfiguration configuration = KinesisVideoClientConfiguration.builder()
                     .withRegion(Regions.US_WEST_2.getName())
-                    .withCredentialsProvider(JavaCredentialsFactory.getKinesisVideoCredentialsProvider(awsCredentialsProvider))
+                    .withCredentialsProvider(JavaCredentialsFactory.createKinesisVideoCredentialsProvider(awsCredentialsProvider))
                     .withStorageCallbacks(new DefaultStorageCallbacks())
                     .withIPVersionFilter(IPVersionFilter.IPV4_AND_IPV6)
                     .build();

--- a/src/main/java/com/amazonaws/kinesisvideo/auth/KinesisVideoCredentials.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/auth/KinesisVideoCredentials.java
@@ -5,6 +5,7 @@ import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -13,15 +14,35 @@ import java.util.Date;
  * Consumer is responsible for checking the {@link #expiration} before using the credentials.
  * <p>
  * If the credentials are non-temporary, the session token will be {@code null} and the expiration
- * will be {@link #CREDENTIALS_NEVER_EXPIRE}.
+ * will be {@link #getCredentialsNeverExpire()}.
  * </p>
  */
 @Immutable
+@ThreadSafe
 public class KinesisVideoCredentials implements Serializable {
     /**
-     * Sentinel value indicating the credentials never expire.
+     * Internal immutable sentinel value indicating the credentials never expire.
      */
+    private static final Date CREDENTIALS_NEVER_EXPIRE_INTERNAL = new Date(Long.MAX_VALUE);
+    
+    /**
+     * Sentinel value indicating the credentials never expire.
+     * @deprecated This exposes a mutable Date object. Use {@link #getCredentialsNeverExpire()} instead.
+     */
+    @Deprecated
     public static final Date CREDENTIALS_NEVER_EXPIRE = new Date(Long.MAX_VALUE);
+    
+    /**
+     * Returns a defensive copy of the sentinel value indicating credentials never expire.
+     * This method should be used instead of the deprecated {@link #CREDENTIALS_NEVER_EXPIRE} constant
+     * to maintain immutability.
+     * 
+     * @return A new Date instance representing credentials that never expire
+     */
+    @Nonnull
+    public static Date getCredentialsNeverExpire() {
+        return new Date(CREDENTIALS_NEVER_EXPIRE_INTERNAL.getTime());
+    }
 
     /**
      * AWS Access Key ID, non-empty.
@@ -56,7 +77,7 @@ public class KinesisVideoCredentials implements Serializable {
      */
     public KinesisVideoCredentials(@Nonnull final String accessKey,
                                    @Nonnull final String secretKey) {
-        this(accessKey, secretKey, null, CREDENTIALS_NEVER_EXPIRE);
+        this(accessKey, secretKey, null, CREDENTIALS_NEVER_EXPIRE_INTERNAL);
     }
 
     /**
@@ -83,14 +104,14 @@ public class KinesisVideoCredentials implements Serializable {
             Preconditions.checkArgument(!sessionToken.isEmpty(), "Session token cannot be empty!");
         }
 
-        Preconditions.checkArgument((sessionToken == null && CREDENTIALS_NEVER_EXPIRE.equals(expiration)) ||
-                        (sessionToken != null && !CREDENTIALS_NEVER_EXPIRE.equals(expiration)),
+        Preconditions.checkArgument((sessionToken == null && CREDENTIALS_NEVER_EXPIRE_INTERNAL.equals(expiration)) ||
+                        (sessionToken != null && !CREDENTIALS_NEVER_EXPIRE_INTERNAL.equals(expiration)),
                 "Temporary credentials should have a session token and non-temporary should not!");
 
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.sessionToken = sessionToken;
-        this.expiration = expiration;
+        this.expiration = new Date(expiration.getTime());
     }
 
     /**
@@ -119,11 +140,11 @@ public class KinesisVideoCredentials implements Serializable {
 
     /**
      * @return When the credentials will no longer be valid. If the credentials are non-temporary,
-     * this will be {@link #CREDENTIALS_NEVER_EXPIRE}.
+     * this will be {@link #getCredentialsNeverExpire()}.
      */
     @Nonnull
     public Date getExpiration() {
-        return this.expiration;
+        return new Date(this.expiration.getTime());
     }
 
     /**
@@ -132,6 +153,6 @@ public class KinesisVideoCredentials implements Serializable {
      * @return true if the credentials are temporary (have an expiration).
      */
     public boolean isTemporary() {
-        return !CREDENTIALS_NEVER_EXPIRE.equals(this.expiration);
+        return !CREDENTIALS_NEVER_EXPIRE_INTERNAL.equals(this.expiration);
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsFactory.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsFactory.java
@@ -6,6 +6,7 @@ import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 import java.time.Duration;
 
 /**
@@ -13,7 +14,8 @@ import java.time.Duration;
  * There are two types of KinesisVideoCredentialsProvider - one that provides temporary credentials (session token),
  * and non-temporary that just provides access key + secret key.
  */
-public class JavaCredentialsFactory {
+@ThreadSafe
+public final class JavaCredentialsFactory {
     private JavaCredentialsFactory() {
         throw new UnsupportedOperationException();
     }
@@ -22,8 +24,8 @@ public class JavaCredentialsFactory {
      * Returns the correct Kinesis Video Credentials Provider based on if the AWS Credentials provider returns a session token or not.
      * Use this if you know your session token lasts for 1 hour.
      */
-    public static KinesisVideoCredentialsProvider getKinesisVideoCredentialsProvider(@Nonnull final AWSCredentialsProvider awsCredentialsProvider) {
-        return getKinesisVideoCredentialsProvider(awsCredentialsProvider, Duration.ofHours(1));
+    public static KinesisVideoCredentialsProvider createKinesisVideoCredentialsProvider(@Nonnull final AWSCredentialsProvider awsCredentialsProvider) {
+        return createKinesisVideoCredentialsProvider(awsCredentialsProvider, Duration.ofHours(1));
     }
 
     /**
@@ -33,8 +35,8 @@ public class JavaCredentialsFactory {
      * @return the correct (temporary/non-temporary) Kinesis Video Credentials Provider based on the AWS Credentials Provider
      */
     @SuppressWarnings({"ConstantConditions"}) // @Nonnull is a compile-time check, it can still be null at runtime
-    public static KinesisVideoCredentialsProvider getKinesisVideoCredentialsProvider(@Nonnull final AWSCredentialsProvider awsCredentialsProvider,
-                                                                                     @Nonnull final Duration credentialsRefreshIntervalFallback) {
+    public static KinesisVideoCredentialsProvider createKinesisVideoCredentialsProvider(@Nonnull final AWSCredentialsProvider awsCredentialsProvider,
+                                                                                        @Nonnull final Duration credentialsRefreshIntervalFallback) {
 
         Preconditions.checkArgument(awsCredentialsProvider != null, "awsCredentialsProvider must not be null");
         Preconditions.checkArgument(credentialsRefreshIntervalFallback != null, "credentialsRefreshIntervalFallback must not be null");

--- a/src/main/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsProviderImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsProviderImpl.java
@@ -27,7 +27,7 @@ public class JavaCredentialsProviderImpl extends AbstractKinesisVideoCredentials
      */
     public JavaCredentialsProviderImpl(@Nonnull final AWSCredentialsProvider awsCredentialsProvider) {
         this.credentialsProvider = Preconditions.checkNotNull(awsCredentialsProvider);
-        tokenExpiration = KinesisVideoCredentials.CREDENTIALS_NEVER_EXPIRE;
+        tokenExpiration = KinesisVideoCredentials.getCredentialsNeverExpire();
         rotationPeriodInMillis = 0;
     }
 
@@ -60,7 +60,7 @@ public class JavaCredentialsProviderImpl extends AbstractKinesisVideoCredentials
             sessionToken = sessionCredentials.getSessionToken();
         }
 
-        if (tokenExpiration != KinesisVideoCredentials.CREDENTIALS_NEVER_EXPIRE) {
+        if (!tokenExpiration.equals(KinesisVideoCredentials.getCredentialsNeverExpire())) {
             tokenExpiration = new Date(System.currentTimeMillis() + rotationPeriodInMillis);
         }
 

--- a/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/client/KinesisVideoJavaClientFactory.java
@@ -1,7 +1,6 @@
 package com.amazonaws.kinesisvideo.java.client;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
 import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
@@ -14,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks;
 import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
-import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsProviderImpl;
 import com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient;
 import com.amazonaws.kinesisvideo.producer.DeviceInfo;
 import com.amazonaws.kinesisvideo.producer.StorageInfo;
@@ -27,8 +25,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.invoke.MethodHandles;
-import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -121,7 +117,7 @@ public final class KinesisVideoJavaClientFactory {
         Preconditions.checkNotNull(awsCredentialsProvider);
 
         final KinesisVideoCredentialsProvider kinesisVideoCredentialsProvider =
-                JavaCredentialsFactory.getKinesisVideoCredentialsProvider(awsCredentialsProvider);
+                JavaCredentialsFactory.createKinesisVideoCredentialsProvider(awsCredentialsProvider);
 
         final KinesisVideoClientConfiguration.Builder builder = KinesisVideoClientConfiguration.builder()
                 .withRegion(regions.getName())

--- a/src/main/java/com/amazonaws/kinesisvideo/java/service/CachedInfoMultiAuthServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/service/CachedInfoMultiAuthServiceCallbacksImpl.java
@@ -12,7 +12,6 @@ import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducer;
 import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
 import com.amazonaws.kinesisvideo.internal.producer.client.KinesisVideoServiceClient;
 import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
-import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsProviderImpl;
 import com.amazonaws.kinesisvideo.producer.ProducerException;
 import com.amazonaws.kinesisvideo.producer.StreamDescription;
 import com.amazonaws.kinesisvideo.producer.StreamStatus;
@@ -289,7 +288,7 @@ public class CachedInfoMultiAuthServiceCallbacksImpl extends DefaultServiceCallb
     public void addCredentialsProviderToCache(String streamName, AWSCredentialsProvider credentialsProvider) {
         Preconditions.checkArgument(!credentialsProviderMap.containsKey(streamName));
         final KinesisVideoCredentialsProvider kvsCredentialsProvider =
-                JavaCredentialsFactory.getKinesisVideoCredentialsProvider(credentialsProvider);
+                JavaCredentialsFactory.createKinesisVideoCredentialsProvider(credentialsProvider);
         credentialsProviderMap.put(streamName, kvsCredentialsProvider);
     }
 

--- a/src/test/java/com/amazonaws/kinesisvideo/auth/KinesisVideoCredentialsTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/auth/KinesisVideoCredentialsTest.java
@@ -3,6 +3,13 @@ package com.amazonaws.kinesisvideo.auth;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,8 +41,7 @@ public class KinesisVideoCredentialsTest {
         assertEquals(ACCESS_KEY, credentials.getAccessKey());
         assertEquals(SECRET_KEY, credentials.getSecretKey());
         assertNull(credentials.getSessionToken());
-        assertEquals(KinesisVideoCredentials.CREDENTIALS_NEVER_EXPIRE, credentials.getExpiration());
-
+        assertEquals(KinesisVideoCredentials.getCredentialsNeverExpire(), credentials.getExpiration());
         assertFalse(credentials.isTemporary());
     }
 
@@ -71,6 +77,7 @@ public class KinesisVideoCredentialsTest {
      * - An IllegalArgumentException is thrown
      */
     @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings({"ConstantConditions"})
     public void whenSecretKeyIsNull_thenThrowsIllegalArgumentException() {
         new KinesisVideoCredentials(ACCESS_KEY, null);
     }
@@ -98,6 +105,7 @@ public class KinesisVideoCredentialsTest {
      * - An IllegalArgumentException is thrown
      */
     @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings({"ConstantConditions"})
     public void whenExpirationIsNull_thenThrowsIllegalArgumentException() {
         new KinesisVideoCredentials(ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, null);
     }
@@ -142,6 +150,317 @@ public class KinesisVideoCredentialsTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void whenCreatingNonTemporaryCredentialsWithSessionToken_thenThrowsIllegalArgumentException() {
-        new KinesisVideoCredentials(ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, KinesisVideoCredentials.CREDENTIALS_NEVER_EXPIRE);
+        new KinesisVideoCredentials(ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, KinesisVideoCredentials.getCredentialsNeverExpire());
+    }
+
+    // ========== THREAD SAFETY TESTS ==========
+
+    /**
+     * Tests that when getExpiration() is called concurrently by multiple threads,
+     * then defensive copies are returned that can be safely modified without affecting internal state.
+     */
+    @Test
+    public void whenGetExpirationCalledConcurrently_thenReturnsDefensiveCopiesSafely() throws InterruptedException {
+        final Date originalExpiration = new Date(System.currentTimeMillis() + 3600000); // 1 hour from now
+        final KinesisVideoCredentials credentials = new KinesisVideoCredentials(
+                ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, originalExpiration);
+
+        final int numThreads = 10;
+        final int operationsPerThread = 100;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch startLatch = new CountDownLatch(1); // All threads wait for this
+        final CountDownLatch completionLatch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    // Wait for all threads to be ready before starting
+                    startLatch.await();
+
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        // Get expiration and modify it
+                        final Date expiration = credentials.getExpiration();
+                        final long originalTime = expiration.getTime();
+
+                        // Modify the returned date
+                        expiration.setTime(0);
+
+                        // Verify the modification didn't affect subsequent calls
+                        final Date newExpiration = credentials.getExpiration();
+                        if (newExpiration.getTime() != originalTime) {
+                            testFailed.set(true);
+                            failureReason.set("Internal state was modified by external date mutation");
+                            return;
+                        }
+
+                        // Verify each call returns a new instance
+                        final Date anotherExpiration = credentials.getExpiration();
+                        if (expiration == anotherExpiration) {
+                            testFailed.set(true);
+                            failureReason.set("getExpiration() returned the same instance instead of defensive copy");
+                            return;
+                        }
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    testFailed.set(true);
+                    failureReason.set("Thread was interrupted: " + e.getMessage());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+
+        assertTrue("Test threads did not complete within timeout",
+                completionLatch.await(10, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+
+        executor.shutdown();
+    }
+
+    /**
+     * Tests that when getCredentialsNeverExpire() is called concurrently by multiple threads,
+     * then defensive copies are returned that can be safely modified without affecting the constant.
+     */
+    @Test
+    public void whenGetCredentialsNeverExpireCalledConcurrently_thenReturnsDefensiveCopiesSafely() throws InterruptedException {
+        final int numThreads = 10;
+        final int operationsPerThread = 100;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        // Get the never expire date and modify it
+                        final Date neverExpire = KinesisVideoCredentials.getCredentialsNeverExpire();
+                        final long originalTime = neverExpire.getTime();
+
+                        // Verify it has the expected value
+                        if (originalTime != Long.MAX_VALUE) {
+                            testFailed.set(true);
+                            failureReason.set("getCredentialsNeverExpire() returned unexpected value");
+                            return;
+                        }
+
+                        // Modify the returned date
+                        neverExpire.setTime(0);
+
+                        // Verify subsequent calls still return the correct value
+                        final Date newNeverExpire = KinesisVideoCredentials.getCredentialsNeverExpire();
+                        if (newNeverExpire.getTime() != Long.MAX_VALUE) {
+                            testFailed.set(true);
+                            failureReason.set("Internal constant was modified by external date mutation");
+                            return;
+                        }
+
+                        // Verify each call returns a new instance
+                        final Date anotherNeverExpire = KinesisVideoCredentials.getCredentialsNeverExpire();
+                        if (neverExpire == anotherNeverExpire) {
+                            testFailed.set(true);
+                            failureReason.set("getCredentialsNeverExpire() returned the same instance instead of defensive copy");
+                            return;
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue("Test threads did not complete within timeout",
+                latch.await(10, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+
+        executor.shutdown();
+    }
+
+    /**
+     * Tests that when multiple threads access all KinesisVideoCredentials methods concurrently,
+     * then no race conditions occur and data remains consistent across all threads.
+     */
+    @Test
+    public void whenAllMethodsAccessedConcurrently_thenNoRaceConditionsOccur() throws InterruptedException {
+        final Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        final KinesisVideoCredentials credentials = new KinesisVideoCredentials(
+                ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, expiration);
+
+        final int numThreads = 20;
+        final int operationsPerThread = 50;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+        final AtomicInteger successfulOperations = new AtomicInteger(0);
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        try {
+                            // Test all getter methods
+                            final String accessKey = credentials.getAccessKey();
+                            final String secretKey = credentials.getSecretKey();
+                            final String sessionToken = credentials.getSessionToken();
+                            final Date exp = credentials.getExpiration();
+                            final boolean isTemp = credentials.isTemporary();
+
+                            // Verify values are consistent
+                            if (!ACCESS_KEY.equals(accessKey) ||
+                                    !SECRET_KEY.equals(secretKey) ||
+                                    !SESSION_TOKEN.equals(sessionToken) ||
+                                    !isTemp) {
+                                testFailed.set(true);
+                                failureReason.set("Inconsistent values returned from concurrent access");
+                                return;
+                            }
+
+                            // Modify the returned date to ensure it doesn't affect internal state
+                            exp.setTime(0);
+
+                            successfulOperations.incrementAndGet();
+                        } catch (final Exception e) {
+                            testFailed.set(true);
+                            failureReason.set("Exception during concurrent access: " + e.getMessage());
+                            return;
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue("Test threads did not complete within timeout",
+                latch.await(15, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+        assertEquals("Not all operations completed successfully",
+                numThreads * operationsPerThread, successfulOperations.get());
+
+        executor.shutdown();
+    }
+
+    /**
+     * Tests that when the deprecated CREDENTIALS_NEVER_EXPIRE constant is accessed concurrently,
+     * then no exceptions occur and backwards compatibility is maintained.
+     */
+    @Test
+    @SuppressWarnings({"deprecation", "ConstantConditions"})
+    public void whenDeprecatedConstantAccessedConcurrently_thenBackwardsCompatibilityMaintained() throws InterruptedException {
+        final int numThreads = 10;
+        final int operationsPerThread = 50;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        // Access the deprecated constant
+                        final Date neverExpire = KinesisVideoCredentials.CREDENTIALS_NEVER_EXPIRE;
+
+                        // Verify it has the expected initial value (might be modified by other threads)
+                        // We can't guarantee the value due to the mutable nature, but we can test access
+                        if (neverExpire == null) {
+                            testFailed.set(true);
+                            failureReason.set("CREDENTIALS_NEVER_EXPIRE returned null");
+                            return;
+                        }
+
+                        // Test that we can read the time without exceptions
+                        final long time = neverExpire.getTime();
+
+                        // Note: We don't modify it here to avoid affecting other tests
+                        // This test just verifies concurrent read access works
+                    }
+                } catch (final Exception e) {
+                    testFailed.set(true);
+                    failureReason.set("Exception during deprecated constant access: " + e.getMessage());
+                    return;
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue("Test threads did not complete within timeout",
+                latch.await(10, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+
+        executor.shutdown();
+    }
+
+    /**
+     * Tests that when multiple KinesisVideoCredentials instances are created concurrently,
+     * then all objects are properly constructed with correct defensive copying behavior.
+     */
+    @Test
+    public void whenCredentialsCreatedConcurrently_thenAllObjectsProperlyConstructed() throws InterruptedException {
+        final Date expiration = new Date(System.currentTimeMillis() + 3600000);
+        final int numThreads = 10;
+        final int objectsPerThread = 20;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch latch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+        final AtomicInteger successfulCreations = new AtomicInteger(0);
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < objectsPerThread; j++) {
+                        try {
+                            // Create credentials with same parameters
+                            final KinesisVideoCredentials creds1 = new KinesisVideoCredentials(
+                                    ACCESS_KEY, SECRET_KEY, SESSION_TOKEN, expiration);
+                            final KinesisVideoCredentials creds2 = new KinesisVideoCredentials(
+                                    ACCESS_KEY, SECRET_KEY);
+
+                            // Verify they have expected properties
+                            if (!creds1.isTemporary() || creds2.isTemporary()) {
+                                testFailed.set(true);
+                                failureReason.set("Incorrect temporary status");
+                                return;
+                            }
+
+                            // Verify defensive copying works
+                            final Date exp1 = creds1.getExpiration();
+                            final Date exp2 = creds1.getExpiration();
+                            if (exp1 == exp2) {
+                                testFailed.set(true);
+                                failureReason.set("getExpiration() returned same instance");
+                                return;
+                            }
+
+                            successfulCreations.incrementAndGet();
+                        } catch (final Exception e) {
+                            testFailed.set(true);
+                            failureReason.set("Exception during concurrent creation: " + e.getMessage());
+                            return;
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue("Test threads did not complete within timeout",
+                latch.await(10, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+        assertEquals("Not all object creations completed successfully",
+                numThreads * objectsPerThread, successfulCreations.get());
+
+        executor.shutdown();
     }
 }

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
@@ -151,7 +151,7 @@ public class ProducerTestBase {
         awsCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
         configuration = KinesisVideoClientConfiguration.builder()
                 .withRegion(Regions.US_WEST_2.getName())
-                .withCredentialsProvider(JavaCredentialsFactory.getKinesisVideoCredentialsProvider(awsCredentialsProvider))
+                .withCredentialsProvider(JavaCredentialsFactory.createKinesisVideoCredentialsProvider(awsCredentialsProvider))
                 .build();
 
         serviceClient = new JavaKinesisVideoServiceClient(log);

--- a/src/test/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsFactoryTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/java/auth/JavaCredentialsFactoryTest.java
@@ -10,6 +10,13 @@ import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,27 +34,27 @@ public class JavaCredentialsFactoryTest {
 
     @Test(expected = IllegalArgumentException.class)
     @SuppressWarnings({"ConstantConditions"}) // Passing null into parameter marked @Nonnull
-    public void whenGetKinesisVideoCredentialsProviderWithNullAwsCredentialsProvider_thenThrowsIllegalArgumentException() {
-        JavaCredentialsFactory.getKinesisVideoCredentialsProvider(null);
+    public void whenCreateKinesisVideoCredentialsProviderWithNullAwsCredentialsProvider_thenThrowsIllegalArgumentException() {
+        JavaCredentialsFactory.createKinesisVideoCredentialsProvider(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     @SuppressWarnings({"ConstantConditions"})
-    public void whenGetKinesisVideoCredentialsProviderWithNullDuration_thenThrowsIllegalArgumentException() {
+    public void whenCreateKinesisVideoCredentialsProviderWithNullDuration_thenThrowsIllegalArgumentException() {
         final AWSCredentialsProvider provider = TestAWSCredentialsProvider.createNonTemporaryCredentialsProvider();
 
-        JavaCredentialsFactory.getKinesisVideoCredentialsProvider(provider, null);
+        JavaCredentialsFactory.createKinesisVideoCredentialsProvider(provider, null);
     }
 
     @Test
     @SuppressWarnings({"ConstantConditions"})
-    public void whenGetKinesisVideoCredentialsProviderWithSessionCredentials_thenReturnsProviderWithRefreshInterval() {
+    public void whenCreateKinesisVideoCredentialsProviderWithSessionCredentials_thenReturnsProviderWithRefreshInterval() {
         // Given
         final AWSCredentialsProvider provider = TestAWSCredentialsProvider.createTemporaryCredentialsProvider();
         final Duration duration = Duration.ofMinutes(30);
 
         // When
-        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.getKinesisVideoCredentialsProvider(provider, duration);
+        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.createKinesisVideoCredentialsProvider(provider, duration);
 
         // Then
         assertNotNull(result);
@@ -68,13 +75,13 @@ public class JavaCredentialsFactoryTest {
 
     @Test
     @SuppressWarnings({"ConstantConditions"})
-    public void whenGetKinesisVideoCredentialsProviderWithNonSessionCredentials_thenReturnsProviderWithoutRefreshInterval() {
+    public void whenCreateKinesisVideoCredentialsProviderWithNonSessionCredentials_thenReturnsProviderWithoutRefreshInterval() {
         // Given
         final AWSCredentialsProvider provider = TestAWSCredentialsProvider.createNonTemporaryCredentialsProvider();
         final Duration duration = Duration.ofMinutes(30);
 
         // When
-        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.getKinesisVideoCredentialsProvider(provider, duration);
+        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.createKinesisVideoCredentialsProvider(provider, duration);
 
         // Then
         assertNotNull(result);
@@ -95,12 +102,12 @@ public class JavaCredentialsFactoryTest {
 
     @Test
     @SuppressWarnings({"ConstantConditions"})
-    public void whenGetKinesisVideoCredentialsProviderWithDefaultDuration_thenUsesOneHourDuration() {
+    public void whenCreateKinesisVideoCredentialsProviderWithDefaultDuration_thenUsesOneHourDuration() {
         // Given
         final AWSCredentialsProvider provider = TestAWSCredentialsProvider.createTemporaryCredentialsProvider();
 
         // When
-        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.getKinesisVideoCredentialsProvider(provider);
+        final KinesisVideoCredentialsProvider result = JavaCredentialsFactory.createKinesisVideoCredentialsProvider(provider);
 
         // Then
         assertNotNull(result);
@@ -166,5 +173,173 @@ public class JavaCredentialsFactoryTest {
         public void refresh() {
             // No-op for testing
         }
+    }
+
+    // ========== THREAD SAFETY TESTS ==========
+
+    /**
+     * Tests that when JavaCredentialsFactory.getKinesisVideoCredentialsProvider() is called
+     * concurrently by multiple threads, then all providers are created successfully without race conditions.
+     */
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void whenCredentialsProviderCreatedConcurrently_thenAllProvidersCreatedSuccessfully() throws InterruptedException {
+        final int numThreads = 10;
+        final int operationsPerThread = 20;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch startLatch = new CountDownLatch(1); // All threads wait for this
+        final CountDownLatch completionLatch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+        final AtomicInteger successfulCreations = new AtomicInteger(0);
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    // Wait for all threads to be ready before starting
+                    startLatch.await();
+
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        try {
+                            // Test creating non-temporary credentials provider
+                            final AWSCredentialsProvider awsProvider1 = TestAWSCredentialsProvider.createNonTemporaryCredentialsProvider();
+                            final KinesisVideoCredentialsProvider provider1 =
+                                    JavaCredentialsFactory.createKinesisVideoCredentialsProvider(awsProvider1);
+
+                            // Test creating temporary credentials provider
+                            final AWSCredentialsProvider awsProvider2 = TestAWSCredentialsProvider.createTemporaryCredentialsProvider();
+                            final KinesisVideoCredentialsProvider provider2 =
+                                    JavaCredentialsFactory.createKinesisVideoCredentialsProvider(
+                                            awsProvider2, Duration.ofMinutes(30));
+
+                            // Verify providers are not null and work correctly
+                            if (provider1 == null || provider2 == null) {
+                                testFailed.set(true);
+                                failureReason.set("Created provider was null");
+                                return;
+                            }
+
+                            // Test that providers can be used to get credentials
+                            final KinesisVideoCredentials creds1 = provider1.getCredentials();
+                            final KinesisVideoCredentials creds2 = provider2.getCredentials();
+
+                            if (creds1 == null || creds2 == null) {
+                                testFailed.set(true);
+                                failureReason.set("Provider returned null credentials");
+                                return;
+                            }
+
+                            // Verify credential properties
+                            if (creds1.isTemporary() || !creds2.isTemporary()) {
+                                testFailed.set(true);
+                                failureReason.set("Incorrect temporary status for credentials");
+                                return;
+                            }
+
+                            successfulCreations.incrementAndGet();
+                        } catch (final Exception e) {
+                            testFailed.set(true);
+                            failureReason.set("Exception during concurrent creation: " + e.getMessage());
+                            return;
+                        }
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    testFailed.set(true);
+                    failureReason.set("Thread was interrupted: " + e.getMessage());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+
+        assertTrue("Test threads did not complete within timeout",
+                completionLatch.await(15, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+        assertEquals("Not all provider creations completed successfully",
+                numThreads * operationsPerThread, successfulCreations.get());
+
+        executor.shutdown();
+    }
+
+    /**
+     * Tests that when multiple threads access factory methods with a shared AWS credentials provider,
+     * then all operations complete successfully with consistent credential values.
+     */
+    @Test
+    public void whenSharedAWSProviderAccessedConcurrently_thenConsistentCredentialsReturned() throws InterruptedException {
+        final AWSCredentialsProvider sharedAwsProvider = TestAWSCredentialsProvider.createTemporaryCredentialsProvider();
+
+        final int numThreads = 15;
+        final int operationsPerThread = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        final CountDownLatch startLatch = new CountDownLatch(1); // All threads wait for this
+        final CountDownLatch completionLatch = new CountDownLatch(numThreads);
+        final AtomicBoolean testFailed = new AtomicBoolean(false);
+        final AtomicReference<String> failureReason = new AtomicReference<>();
+        final AtomicInteger successfulOperations = new AtomicInteger(0);
+
+        for (int i = 0; i < numThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    // Wait for all threads to be ready before starting
+                    startLatch.await();
+
+                    for (int j = 0; j < operationsPerThread; j++) {
+                        try {
+                            // Create provider using shared AWS provider
+                            final KinesisVideoCredentialsProvider provider =
+                                    JavaCredentialsFactory.createKinesisVideoCredentialsProvider(
+                                            sharedAwsProvider, Duration.ofHours(1));
+
+                            // Get credentials and verify they work
+                            final KinesisVideoCredentials credentials = provider.getCredentials();
+
+                            if (credentials == null) {
+                                testFailed.set(true);
+                                failureReason.set("Provider returned null credentials");
+                                return;
+                            }
+
+                            // Verify credential values are consistent
+                            if (!TEST_ACCESS_KEY.equals(credentials.getAccessKey()) ||
+                                    !TEST_SECRET_KEY.equals(credentials.getSecretKey()) ||
+                                    !TEST_SESSION_TOKEN.equals(credentials.getSessionToken()) ||
+                                    !credentials.isTemporary()) {
+                                testFailed.set(true);
+                                failureReason.set("Inconsistent credential values");
+                                return;
+                            }
+
+                            successfulOperations.incrementAndGet();
+                        } catch (final Exception e) {
+                            testFailed.set(true);
+                            failureReason.set("Exception during concurrent access: " + e.getMessage());
+                            return;
+                        }
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    testFailed.set(true);
+                    failureReason.set("Thread was interrupted: " + e.getMessage());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+
+        assertTrue("Test threads did not complete within timeout",
+                completionLatch.await(10, TimeUnit.SECONDS));
+        assertFalse("Thread safety test failed: " + failureReason.get(), testFailed.get());
+        assertEquals("Not all operations completed successfully",
+                numThreads * operationsPerThread, successfulOperations.get());
+
+        executor.shutdown();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
- Part 2 of #232

*What was changed?*
- Enhanced thread safety and immutability of `KinesisVideoCredentials` and `JavaCredentialsFactory` classes
- Fixed mutable Date object issues
- Added comprehensive thread safety test coverage with 7 new concurrent access tests

*Why was it changed?*
- The public static `CREDENTIALS_NEVER_EXPIRE` constant was a mutable `Date` object accessible by all threads
- Constructor and getter methods directly assigned/returned `Date` references without defensive copying, allowing external code to modify internal state and break immutability guarantees

*How was it changed?*
- Modified `KinesisVideoCredentials` constructor to create defensive copies of `Date` parameters
- Updated `getExpiration()` method to return defensive copies instead of internal references
- Created private `CREDENTIALS_NEVER_EXPIRE_INTERNAL` constant for internal use
- Added `getCredentialsNeverExpire()` method returning defensive copies while maintaining existing public constant with `@Deprecated`
- Factory method naming updated from `get` to `create` for semantic clarity (have not released it yet so we're not breaking any backwards compatibility). Adjust samples usages and test names.

*What testing was done for the changes?*
- Created new multi-threaded unit tests, following the latch pattern to ensure all threads begin execution simultaneously, creating maximum contention

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

