### PR TITLE
Upgrade AWS SDK Java from v1.11 to v1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.602</version>
+                <version>1.12.788</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
@@ -1,5 +1,6 @@
 package com.amazonaws.kinesisvideo.internal.service;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentials;
 import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
 import com.amazonaws.kinesisvideo.auth.StaticCredentialsProvider;
@@ -668,6 +669,8 @@ public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
         // TODO: Implement this properly
         if (e == null) {
             return HTTP_OK;
+        } else if (e instanceof AmazonServiceException) {
+            return ((AmazonServiceException) e).getStatusCode();
         } else if (e.getClass().getName().endsWith(RESOURCE_NOT_FOUND)) {
             return HTTP_NOT_FOUND;
         } else if (e.getClass().getName().endsWith(RESOURCE_IN_USE)) {

--- a/src/test/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImplTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImplTest.java
@@ -1,0 +1,138 @@
+package com.amazonaws.kinesisvideo.internal.service;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.kinesisvideo.util.StreamInfoConstants;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link DefaultServiceCallbacksImpl} class.
+ * Tests focus on the getStatusCodeFromException method behavior.
+ */
+public class DefaultServiceCallbacksImplTest {
+
+    private static final Logger log = LogManager.getLogger(DefaultServiceCallbacksImplTest.class);
+
+    private AmazonKinesisVideo awsSdkKinesisVideoClient;
+
+    @Before
+    public void setUp() {
+        this.awsSdkKinesisVideoClient = AmazonKinesisVideoClientBuilder.defaultClient();
+    }
+
+    @After
+    public void tearDown() {
+        this.awsSdkKinesisVideoClient.shutdown();
+    }
+
+    @Test
+    public void whenExceptionIsNull_thenReturnsHttpOk() {
+        final int statusCode = DefaultServiceCallbacksImpl.getStatusCodeFromException(null);
+        assertEquals(StreamInfoConstants.HTTP_OK, statusCode);
+    }
+
+    /**
+     * Tests that when a stream does not exist:
+     * - Returns HTTP_NOT_FOUND (404)
+     */
+    @Test
+    public void whenExceptionIsResourceNotFoundException_thenReturnsHttpNotFound() {
+        final String streamName = "TestStream-DoesNotExist-Nope";
+        final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest()
+                .withStreamName(streamName);
+
+        try {
+            this.awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+            fail("An exception should have been thrown");
+        } catch (final Exception e) {
+            log.info("Received exception (expected): {}", e.getClass().getName(), e);
+            final int statusCode = DefaultServiceCallbacksImpl.getStatusCodeFromException(e);
+            assertEquals("ResourceNotFound should have returned " + StreamInfoConstants.HTTP_NOT_FOUND,
+                    StreamInfoConstants.HTTP_NOT_FOUND, statusCode);
+        }
+    }
+
+    /**
+     * Tests that it will translate a bad request correctly:
+     * - Pass both streamARN and streamName to describeStream API
+     * - 400 InvalidArgumentException expected to be returned
+     * - Returns HTTP_BAD_REQUEST (400)
+     */
+    @Test
+    public void whenExceptionIsBadRequest_thenReturnsBadRequest() {
+        final String streamName = "TestStream";
+        final String streamARN = "arn:aws:kinesisvideo:us-west-2:123456789012:stream/TestStream/1691560751966";
+
+        final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest()
+                .withStreamName(streamName)
+                .withStreamARN(streamARN);
+
+        try {
+            this.awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+            fail("An exception should have been thrown");
+        } catch (final Exception e) {
+            log.info("Received exception (expected): {}", e.getClass().getName(), e);
+            final int statusCode = DefaultServiceCallbacksImpl.getStatusCodeFromException(e);
+            assertEquals("InvalidArgumentException should have returned " + StreamInfoConstants.HTTP_BAD_REQUEST,
+                    StreamInfoConstants.HTTP_BAD_REQUEST, statusCode);
+        }
+    }
+
+    /**
+     * Tests that when exception class name ends with "AccessDeniedException":
+     * - Uses bad credentials
+     * - Expects UnrecognizedClientException (403) to be returned
+     * - Returns HTTP_ACCESS_DENIED (403)
+     */
+    @Test
+    public void whenExceptionIsAccessDeniedException_thenReturnsHttpAccessDenied() {
+        final String streamName = "demo-stream";
+
+        final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest()
+                .withStreamName(streamName)
+                .withRequestCredentialsProvider(new AWSCredentialsProvider() {
+                    @Override
+                    public AWSCredentials getCredentials() {
+                        return new BasicAWSCredentials("accessKey", "secretKey");
+                    }
+
+                    @Override
+                    public void refresh() {
+                        // No-op
+                    }
+                });
+
+        try {
+            this.awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+            fail("An exception should have been thrown");
+        } catch (final Exception e) {
+            log.info("Received exception (expected): {}", e.getClass().getName(), e);
+            final int statusCode = DefaultServiceCallbacksImpl.getStatusCodeFromException(e);
+            assertEquals("UnrecognizedClientException should have returned " + StreamInfoConstants.HTTP_ACCESS_DENIED,
+                    StreamInfoConstants.HTTP_ACCESS_DENIED, statusCode);
+        }
+    }
+
+    /**
+     * Tests that when exception doesn't match any specific patterns:
+     * - Returns HTTP_BAD_REQUEST (400) as default
+     */
+    @Test
+    public void whenExceptionIsGeneric_thenReturnsHttpBadRequest() {
+        final Exception exception = new RuntimeException("Generic error");
+        final int statusCode = DefaultServiceCallbacksImpl.getStatusCodeFromException(exception);
+        assertEquals(StreamInfoConstants.HTTP_BAD_REQUEST, statusCode);
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Upgrade AWS SDK Java from 1.11 to 1.12
- Add unit tests to confirm the error codes returned

*Why was it changed?*
- I observed an issue in v1.11 where it would return a 400 error code for ResourceNotFoundException in Java 17 and 21, whereas it properly returned 404 error code in Java 11. This is because it returned "com.amazonaws.services.kinesisvideo.model.ResourceNotFoundException" in Java 11, but in Java 17+21, it returned AmazonServiceException.
- After I updated it from v1.11. to v1.12, the issue went away in Java 17 and 21.
- PIC makes a different decision for 404 vs 400 ([here](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/client/src/StreamState.c#L228-L239)), so making sure the correct status code is being returned is very important!

*How was it changed?*
- Upgrade from v1.11 to v1.12 (latest)
- Add unit + integ tests to check the codes are translated correctly

*What testing was done for the changes?*
- Perform a real 404 not found and verified the result
- Perform a real 403 (access denied) and verified the result
- Perform a real bad request (400) and verified the result
- The unit tests previously failed in the 1.11 version with Java 21 but now pass with the 1.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
