### PR TITLE
Deprecate putmedia demo

### DIFF
--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/PutMediaDemo.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/PutMediaDemo.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
  *  2. Convert MP4 to MKV
  *      ffmpeg -i input.mp4 -b:v 10M -minrate 10M -maxrate 10M -bufsize 10M -bf 0 input.mkv
  */
+@Deprecated
 public final class PutMediaDemo {
     private static final String DEFAULT_REGION = "us-west-2";
     private static final String PUT_MEDIA_API = "/putMedia";


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Deprecate PutMediaDemo

*Why was it changed?*
- Recommend to use the Producer SDK instead, which handles the MKV packaging.

*How was it changed?*
- Add Deprecated annotation. Current users can still use it.

*What testing was done for the changes?*
- Not applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
