### PR TITLE
Add logs for streamcallbacks and overview

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/producer/jni/NativeKinesisVideoProducerJni.java
@@ -656,6 +656,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
             throw new ProducerException("Invalid stream handle.", STATUS_INVALID_OPERATION);
         }
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] streamUnderflowReport", kinesisVideoProducerStream.getStreamName());
         kinesisVideoProducerStream.streamUnderflowReport();
     }
 
@@ -664,6 +665,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
      */
     private void storageOverflowPressure(final long remainingSize)
     {
+        mLog.trace("storageOverflowPressure - {}", remainingSize);
         mStorageCallbacks.storageOverflowPressure(remainingSize);
     }
 
@@ -676,6 +678,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] bufferDurationOverflowPressure - {}", kinesisVideoProducerStream.getStreamName(), remainDuration);
         kinesisVideoProducerStream.bufferDurationOverflowPressure(remainDuration);
     }
 
@@ -689,6 +692,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] streamLatencyPressure - {}", kinesisVideoProducerStream.getStreamName(), duration);
         kinesisVideoProducerStream.streamLatencyPressure(duration);
     }
 
@@ -702,6 +706,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] streamConnectionStale - {}", kinesisVideoProducerStream.getStreamName(), lastAckDuration);
         kinesisVideoProducerStream.streamConnectionStale(lastAckDuration);
     }
 
@@ -720,6 +725,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] fragmentAckReceived - {}", kinesisVideoProducerStream.getStreamName(), fragmentAck);
         kinesisVideoProducerStream.fragmentAckReceived(uploadHandle, fragmentAck);
     }
 
@@ -733,6 +739,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] droppedFrameReport - {}", kinesisVideoProducerStream.getStreamName(), frameTimecode);
         kinesisVideoProducerStream.droppedFrameReport(frameTimecode);
     }
 
@@ -746,6 +753,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] droppedFragmentReport - {}", kinesisVideoProducerStream.getStreamName(), fragmentTimecode);
         kinesisVideoProducerStream.droppedFragmentReport(fragmentTimecode);
     }
 
@@ -759,6 +767,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
         }
 
         final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+        mLog.trace("[{}] streamErrorReport - {}, 0x{}", kinesisVideoProducerStream.getStreamName(), fragmentTimecode, Long.toHexString(statusCode));
         kinesisVideoProducerStream.streamErrorReport(uploadHandle, fragmentTimecode, statusCode);
     }
 
@@ -788,6 +797,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
                 }
 
                 final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+                mLog.trace("[{}] streamReady", kinesisVideoProducerStream.getStreamName());
                 kinesisVideoProducerStream.streamReady();
             }
         }
@@ -804,6 +814,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
             }
 
             final KinesisVideoProducerStream kinesisVideoProducerStream = mKinesisVideoHandleMap.get(streamHandle);
+            mLog.trace("[{}] streamClosed", kinesisVideoProducerStream.getStreamName());
             kinesisVideoProducerStream.streamClosed(uploadHandle);
         }
     }
@@ -819,6 +830,7 @@ public class NativeKinesisVideoProducerJni implements KinesisVideoProducer {
             }
 
             mIsReady = true;
+            mLog.trace("clientReady");
 
             // Release the ready latch
             mReadyLatch.countDown();

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -394,6 +394,43 @@ dependency/libkvspic/kvspic-src/src/state/src/State.c
 7. Return bytes filled in buffer</pre>
     </div>
 </details>
+
+<details>
+    <summary style="font-size:1.5em; color:#720e9e"><strong>Stream Callbacks</strong></summary>
+    <div>
+        <h3>What do Stream Callbacks do?</h3>
+        <div>
+            <p>
+                Stream callbacks notify the user of events happening during streaming, following the standard observability pattern.
+                These callbacks enable client applications to customize the processing of streaming events asynchronously.
+            </p>
+            <p>Examples include: <code>streamErrorReport</code> and <code>fragmentAckReceived</code>.</p>
+            <div style="background-color: #e5e5ff; padding: 15px; border-left: 4px solid #ccccff; margin: 15px 0;">
+                <strong>Note:</strong>
+                <p>See <a href="https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-callbacks.html">AWS Documentation</a> for more information.</p>
+            </div>
+        </div>
+
+        <h3>Configuration</h3>
+        <div>
+            <p><strong>Summary:</strong> Configure the media source with the callbacks for each stream.</p>
+            <p>
+                During media source registration with the client, the client will ask the media source for Stream Callbacks.
+                If none are provided, it will use the default (no-op) callbacks.
+            </p>
+        </div>
+
+        <h3>Flow</h3>
+        <div>
+            <ol>
+                <li>PIC calls JNI</li>
+                <li>JNI calls NativeKinesisVideoProducerJni (Java)</li>
+                <li>NativeKinesisVideoProducerJni forwards the call to NativeKinesisVideoProducerStream</li>
+                <li>NativeKinesisVideoProducerStream forwards the call to the configured callbacks in the media source</li>
+            </ol>
+        </div>
+    </div>
+</details>
 </div>
 
 <h3>See also:</h3>


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added logs when the stream callbacks get invoked
- Added documentation overview for stream callbacks

*Why was it changed?*
- Making it easier for new developers to onboard

*How was it changed?*
- Added trace logs in the Java methods called by the JNI
- Added a section to the overview Javadoc

*What testing was done for the changes?*
- Checked the new section in the local javadoc

<img width="1512" height="684" alt="image" src="https://github.com/user-attachments/assets/25230127-46a3-4723-b826-3cccd295ff03" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
