### PR TITLE
Fix: Making sure native exceptions get propagated to Java layer

### DIFF
--- a/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -2632,6 +2632,8 @@ VOID KinesisVideoClientWrapper::logPrintFunc(UINT32 level, PCHAR tag, PCHAR fmt,
     CHAR buffer[MAX_LOG_MESSAGE_LENGTH];
     va_list list;
     INT32 envState;
+    jthrowable pendingException = NULL;
+    BOOL hadPendingException = FALSE;
 
     // Prevent infinite logging loops if mGlobalJniObjRef has already been freed
     if (mGlobalJniObjRef == NULL) {
@@ -2657,6 +2659,13 @@ VOID KinesisVideoClientWrapper::logPrintFunc(UINT32 level, PCHAR tag, PCHAR fmt,
         attached = TRUE;
     }
 
+    // Save any pending exception before we do JNI calls
+    if (env->ExceptionCheck()) {
+        hadPendingException = TRUE;
+        pendingException = env->ExceptionOccurred();
+        env->ExceptionClear(); // Clear it temporarily so we can make JNI calls
+    }
+
     va_start(list, fmt);
     vsnprintf(buffer, MAX_LOG_MESSAGE_LENGTH, fmt, list);
     va_end(list);
@@ -2673,7 +2682,15 @@ VOID KinesisVideoClientWrapper::logPrintFunc(UINT32 level, PCHAR tag, PCHAR fmt,
 
     env->CallVoidMethod(mGlobalJniObjRef, mLogPrintMethodId, level, jstrTag, jstrFmt, jstrBuffer);
 
-    CHK_JVM_EXCEPTION(env);
+    // Don't use CHK_JVM_EXCEPTION here as it would clear our saved exception
+    // Just check if the logging call itself threw an exception
+    if (env->ExceptionCheck()) {
+        // The logging call threw an exception, clear it and log it
+        jthrowable loggingException = env->ExceptionOccurred();
+        env->ExceptionClear();
+        std::cerr << "An exception occurred during logging call" << std::endl;
+        env->DeleteLocalRef(loggingException);
+    }
 
     /*
     Sample logs from PIC as displayed by log4j2 in Java Producer SDK
@@ -2700,6 +2717,12 @@ CleanUp:
 
     if (jstrBuffer != NULL) {
         env->DeleteLocalRef(jstrBuffer);
+    }
+
+    // Restore the pending exception if we had one
+    if (hadPendingException && pendingException != NULL) {
+        env->Throw(pendingException);
+        env->DeleteLocalRef(pendingException);
     }
 
     // Detach the thread if we have attached it to JVM


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Modified `KinesisVideoClientWrapper::logPrintFunc()` to preserve pending JNI exceptions during logging operations
- Fixed bug where native exceptions were being silently swallowed when `LEAVE()` macro was called at the end of methods

*Why was it changed?*
- The existing logging function would clear any pending JNI exceptions when called, causing native exceptions to be lost when the `LEAVE()` macro (which calls logging) was positioned at the end of methods
- This resulted in silent failures where exceptions that should have been propagated to Java were instead cleared

- **Exception handling flow:**
  - Before: Exception → LEAVE() → logPrintFunc() → Exception cleared → Silent failure in Java (method executed successfully without exceptions)
  - After: Exception → LEAVE() → logPrintFunc() → Exception preserved and restored → Proper propagation (ProducerException thrown in Java)

*How was it changed?*
- Added exception preservation logic that saves any pending exception before making JNI calls
- Temporarily clears the exception to allow logging JNI calls to proceed
- Restores the original exception after logging is complete
- Handles logging call exceptions separately without interfering with the preserved exception

*What testing was done for the changes?*
- Checked that ProducerException was actually thrown using DemoAppMain with a stream that doesn't exist.

<img width="1433" height="497" alt="image" src="https://github.com/user-attachments/assets/2d104a61-a8be-4d47-89fb-eb93e4a0b087" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
