### PR TITLE
Add retryStrategy properly and new constructors for the ClientInfo and DeviceInfo

### DIFF
--- a/CMake/Dependencies/libkvspic-CMakeLists.txt
+++ b/CMake/Dependencies/libkvspic-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvspic-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-pic.git
-    GIT_TAG           v1.2.0
+    GIT_TAG           kvsretrystrategy-config
     GIT_SHALLOW       TRUE
     GIT_PROGRESS      TRUE
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/kvspic-src"

--- a/jni/com/amazonaws/kinesis/video/producer/jni/ClientRegistry.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/ClientRegistry.cpp
@@ -5,6 +5,11 @@ ClientRegistry& ClientRegistry::getInstance() {
     return instance;
 }
 
+SIZE_T ClientRegistry::getCurrentNumberClients() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return clients_.size();
+}
+
 std::pair<SIZE_T, UINT32> ClientRegistry::addClient(KinesisVideoClientWrapper* client) {
     std::lock_guard<std::mutex> lock(mutex_);
     clients_.push_back(client);

--- a/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -17,8 +17,8 @@ KinesisVideoClientWrapper::KinesisVideoClientWrapper(JNIEnv* env,
     // Double-checked locking pattern to prevent race condition in globalCustomLogPrintFn assignment
     // The first successful client will set the global logPrintFn in PIC's inputValidator to this static logPrintFunc
     static std::mutex clientCreationMutex;
-    static volatile bool firstClientCreated = false;
-    
+    bool firstClientCreated = ClientRegistry::getInstance().getCurrentNumberClients() > 0;
+
     // Fast path: if first client already created, proceed without locking
     std::unique_lock<std::mutex> lock(clientCreationMutex, std::defer_lock);
     if (!firstClientCreated) {
@@ -50,7 +50,6 @@ KinesisVideoClientWrapper::KinesisVideoClientWrapper(JNIEnv* env,
     // Creating the client object might return an error as well so freeing potentially allocated tags right after the call.
     retStatus = createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &mClientHandle);
     if (STATUS_SUCCEEDED(retStatus) && isFirstClient) {
-        firstClientCreated = true;
         clientRegistryInfo = ClientRegistry::getInstance().addClient(this); // Note: 'this' cannot be null
         mJVMContext.clientId = clientRegistryInfo.second;
     }
@@ -74,6 +73,7 @@ KinesisVideoClientWrapper::~KinesisVideoClientWrapper()
 {
     STATUS retStatus = STATUS_SUCCESS;
     JNIEnv *env = NULL;
+    SIZE_T clientsLeft;
 
     if (this->getJVM() == NULL) {
         return;
@@ -93,7 +93,7 @@ KinesisVideoClientWrapper::~KinesisVideoClientWrapper()
     }
 
     // 2. Remove from registry (this will block if logging is in progress)
-    ClientRegistry::getInstance().removeClient(this);
+    clientsLeft = ClientRegistry::getInstance().removeClient(this);
 
     // 3. Clean up reference to NativeKinesisVideoProducerJni java object
     if (mJVMContext.javaObjectRef != NULL) {

--- a/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -20,12 +20,16 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
         CHK(FALSE, STATUS_INVALID_OPERATION);
     }
 
+    // Null-initialize the DeviceInfo (and ClientInfo) structs embedded within it
+    MEMSET(pDeviceInfo, 0x00, SIZEOF(DeviceInfo));
+
     // Retrieve the methods and call it
     methodId = env->GetMethodID(cls, "getVersion", "()I");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getVersion");
     } else {
         pDeviceInfo->version = env->CallIntMethod(deviceInfo, methodId);
+        DLOGI("Using DeviceInfo version %d", pDeviceInfo->version);
         CHK_JVM_EXCEPTION(env);
     }
 
@@ -122,6 +126,9 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
         }
     }
 
+    // V1 fields
+    CHK(pDeviceInfo->version >= 1, STATUS_SUCCESS);
+
     methodId = env->GetMethodID(cls, "getClientId", "()Ljava/lang/String;");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getClientId");
@@ -161,6 +168,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
     STATUS retStatus = STATUS_SUCCESS;
     jmethodID methodId = NULL;
     const char *retChars;
+    jobject kvsRetryStrategy = NULL;
 
     CHECK(env != NULL && clientInfo != NULL && pClientInfo != NULL);
 
@@ -177,6 +185,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         DLOGW("Couldn't find method id getVersion");
     } else {
         pClientInfo->version = env->CallIntMethod(clientInfo, methodId);
+        DLOGI("Using ClientInfo version %d", pClientInfo->version);
         CHK_JVM_EXCEPTION(env);
     }
 
@@ -204,22 +213,6 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         CHK_JVM_EXCEPTION(env);
     }
 
-    methodId = env->GetMethodID(cls, "getServiceConnectionTimeout", "()J");
-    if (methodId == NULL) {
-        DLOGW("Couldn't find method id getServiceConnectionTimeout");
-    } else {
-        pClientInfo->serviceCallConnectionTimeout = env->CallLongMethod(clientInfo, methodId);
-        CHK_JVM_EXCEPTION(env);
-    }
-
-    methodId = env->GetMethodID(cls, "getServiceCompletionTimeout", "()J");
-    if (methodId == NULL) {
-        DLOGW("Couldn't find method id getServiceCompletionTimeout");
-    } else {
-        pClientInfo->serviceCallCompletionTimeout = env->CallLongMethod(clientInfo, methodId);
-        CHK_JVM_EXCEPTION(env);
-    }
-
     methodId = env->GetMethodID(cls, "getOfflineBufferAvailabilityTimeout", "()J");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getOfflineBufferAvailabilityTimeout");
@@ -244,11 +237,64 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
         CHK_JVM_EXCEPTION(env);
     }
 
+    // V1 fields
+    CHK(pClientInfo->version >= 1, STATUS_SUCCESS);
+
+    methodId = env->GetMethodID(cls, "getMetricLoggingPeriod", "()J");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getMetricLoggingPeriod");
+    } else {
+        pClientInfo->metricLoggingPeriod = env->CallLongMethod(clientInfo, methodId);
+        CHK_JVM_EXCEPTION(env);
+    }
+
+    // V2 fields
+    CHK(pClientInfo->version >= 2, STATUS_SUCCESS);
+
     methodId = env->GetMethodID(cls, "getAutomaticStreamingFlags", "()I");
     if (methodId == NULL) {
         DLOGW("Couldn't find method id getAutomaticStreamingFlags");
     } else {
         pClientInfo->automaticStreamingFlags = (AUTOMATIC_STREAMING_FLAGS) env->CallIntMethod(clientInfo, methodId);
+        CHK_JVM_EXCEPTION(env);
+    }
+
+    methodId = env->GetMethodID(cls, "getReservedCallbackPeriod", "()J");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getReservedCallbackPeriod");
+    } else {
+        pClientInfo->reservedCallbackPeriod = env->CallLongMethod(clientInfo, methodId);
+        CHK_JVM_EXCEPTION(env);
+    }
+
+    methodId = env->GetMethodID(cls, "getKvsRetryStrategy", "()Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategy;");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getKvsRetryStrategy");
+    } else {
+        kvsRetryStrategy = (jobject) env->CallObjectMethod(clientInfo, methodId);
+        CHK_JVM_EXCEPTION(env);
+
+        if (kvsRetryStrategy != NULL && !setKvsRetryStrategy(env, kvsRetryStrategy, &pClientInfo->kvsRetryStrategy, &pClientInfo->kvsRetryStrategyCallbacks)) {
+            DLOGW("Failed getting/setting KvsRetryStrategy.");
+        }
+    }
+
+    // V3 fields
+    CHK(pClientInfo->version >= 3, STATUS_SUCCESS);
+
+    methodId = env->GetMethodID(cls, "getServiceConnectionTimeout", "()J");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getServiceConnectionTimeout");
+    } else {
+        pClientInfo->serviceCallConnectionTimeout = env->CallLongMethod(clientInfo, methodId);
+        CHK_JVM_EXCEPTION(env);
+    }
+
+    methodId = env->GetMethodID(cls, "getServiceCompletionTimeout", "()J");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getServiceCompletionTimeout");
+    } else {
+        pClientInfo->serviceCallCompletionTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
     }
 
@@ -258,6 +304,165 @@ CleanUp:
     return STATUS_FAILED(retStatus) ? FALSE : TRUE;
 }
 
+BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrategy pKvsRetryStrategy,
+                         PKvsRetryStrategyCallbacks pCallbacks)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    jmethodID methodId = NULL;
+    jclass cls = NULL;
+    jobject exponentialBackoffConfig = NULL;
+    PExponentialBackoffRetryStrategyConfig pNativeConfig = NULL;
+
+    CHK(env != NULL && pKvsRetryStrategy != NULL, STATUS_NULL_ARG);
+    CHK_WARN(kvsRetryStrategy != NULL, STATUS_INVALID_OPERATION, "Failed to get Java kvsRetryStrategy class.");
+
+    cls = env->GetObjectClass(kvsRetryStrategy);
+    CHK_WARN(cls != NULL, STATUS_INVALID_OPERATION, "Failed to create Java kvsRetryStrategy class.");
+
+    // Get retry strategy type
+    methodId = env->GetMethodID(cls, "getRetryStrategyTypeValue", "()I");
+    if (methodId == NULL) {
+        DLOGW("Couldn't find method id getRetryStrategyTypeValue, setting retryStrategyType to EXPONENTIAL_BACKOFF_WAIT.");
+        pKvsRetryStrategy->retryStrategyType = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
+    } else {
+        pKvsRetryStrategy->retryStrategyType = (KVS_RETRY_STRATEGY_TYPE) env->CallIntMethod(kvsRetryStrategy, methodId);
+        CHK_JVM_EXCEPTION(env);
+    }
+
+    // Get exponential backoff config (if strategy type is EXPONENTIAL_BACKOFF_WAIT)
+    if (pKvsRetryStrategy->retryStrategyType == KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT) {
+        methodId = env->GetMethodID(cls, "getExponentialBackoffConfig", "()Lcom/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfig;");
+        if (methodId != NULL) {
+            exponentialBackoffConfig = env->CallObjectMethod(kvsRetryStrategy, methodId);
+            CHK_JVM_EXCEPTION(env);
+
+            if (exponentialBackoffConfig != NULL) {
+                // Allocate native config struct
+                pNativeConfig = (PExponentialBackoffRetryStrategyConfig) MEMCALLOC(1, SIZEOF(ExponentialBackoffRetryStrategyConfig));
+                CHK_WARN(pNativeConfig != NULL, STATUS_NOT_ENOUGH_MEMORY, "Failed to allocate native config");
+
+                // Convert Java config to native config
+                if (setExponentialBackoffRetryStrategyConfig(env, exponentialBackoffConfig, pNativeConfig)) {
+                    DLOGE("Successfully converted Java config to native config");
+                } else {
+                    DLOGE("Failed to convert Java config to native config, using default");
+                    MEMFREE(pNativeConfig);
+                    pNativeConfig = NULL;
+                }
+            } else {
+                DLOGE("No custom config provided, PIC will use defaults");
+            }
+        } else {
+            DLOGE("Couldn't find getExponentialBackoffConfig method");
+        }
+    }
+
+    // Set the config pointer (NULL means use PIC defaults)
+    pKvsRetryStrategy->pRetryStrategyConfig = (PRetryStrategyConfig) pNativeConfig;
+    DLOGE("The retry stratgy config is: %p", pNativeConfig);
+
+    // PIC will handle setting pRetryStrategy when the strategy is created
+    pKvsRetryStrategy->pRetryStrategy = NULL;
+
+    pCallbacks->createRetryStrategyFn = exponentialBackoffRetryStrategyCreate;
+    pCallbacks->freeRetryStrategyFn = exponentialBackoffRetryStrategyFree;
+    pCallbacks->executeRetryStrategyFn = getExponentialBackoffRetryStrategyWaitTime;
+    pCallbacks->getCurrentRetryAttemptNumberFn = getExponentialBackoffRetryCount;
+
+    DLOGE("Successfully configured retry strategy: type=%d, config=%p",
+          pKvsRetryStrategy->retryStrategyType, pKvsRetryStrategy->pRetryStrategyConfig);
+
+CleanUp:
+    if (STATUS_FAILED(retStatus) && pNativeConfig != NULL) {
+        MEMFREE(pNativeConfig);
+    }
+    return STATUS_FAILED(retStatus) ? FALSE : TRUE;
+}
+
+BOOL setExponentialBackoffRetryStrategyConfig(JNIEnv *env, jobject exponentialBackoffConfig, PExponentialBackoffRetryStrategyConfig pConfig)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    jmethodID methodId = NULL;
+    jclass cls = NULL;
+
+    CHK(env != NULL && pConfig != NULL, STATUS_NULL_ARG);
+    CHK_WARN(exponentialBackoffConfig != NULL, STATUS_INVALID_OPERATION, "ExponentialBackoffRetryStrategyConfig is null");
+
+    cls = env->GetObjectClass(exponentialBackoffConfig);
+    CHK_WARN(cls != NULL, STATUS_INVALID_OPERATION, "Failed to get ExponentialBackoffRetryStrategyConfig class");
+
+    // Get maxRetryCount
+    methodId = env->GetMethodID(cls, "getMaxRetryCount", "()J");
+    if (methodId != NULL) {
+        pConfig->maxRetryCount = env->CallLongMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+    } else {
+        DLOGW("Couldn't find method id getMaxRetryCount");
+    }
+
+    // Get maxRetryWaitTime
+    methodId = env->GetMethodID(cls, "getMaxRetryWaitTimeMs", "()J");
+    if (methodId != NULL) {
+        long javaValue = env->CallLongMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+        pConfig->maxRetryWaitTime = (javaValue == 0) ?
+            (DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS) :
+            ((UINT64) javaValue);
+    } else {
+        DLOGW("Couldn't find method id getMaxRetryWaitTimeMs, using PIC default");
+        pConfig->maxRetryWaitTime = DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    }
+
+    // Get retryFactorTime (0 = use PIC default)
+    methodId = env->GetMethodID(cls, "getRetryFactorTimeMs", "()J");
+    if (methodId != NULL) {
+        long javaValue = env->CallLongMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+        pConfig->retryFactorTime = (javaValue == 0) ?
+            (DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS) :
+            ((UINT64) javaValue);
+    } else {
+        DLOGW("Couldn't find method id getRetryFactorTimeMs, using PIC default");
+        pConfig->retryFactorTime = DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS;
+    }
+
+    // Get minTimeToResetRetryState (0 = use PIC default)
+    methodId = env->GetMethodID(cls, "getMinTimeToResetRetryStateMs", "()J");
+    if (methodId != NULL) {
+        long javaValue = env->CallLongMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+        pConfig->minTimeToResetRetryState = (javaValue == 0) ?
+            (DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS) :
+            ((UINT64) javaValue);
+    } else {
+        DLOGW("Couldn't find method id getMinTimeToResetRetryStateMs, using PIC default");
+        pConfig->minTimeToResetRetryState = DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS;
+    }
+
+    methodId = env->GetMethodID(cls, "getJitterTypeValue", "()I");
+    if (methodId != NULL) {
+        int javaValue = env->CallIntMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+        pConfig->jitterType = (javaValue == 0) ? FULL_JITTER : (ExponentialBackoffJitterType) javaValue;
+    } else {
+        DLOGW("Couldn't find method id getJitterTypeValue");
+    }
+
+    methodId = env->GetMethodID(cls, "getJitterFactor", "()J");
+    if (methodId != NULL) {
+        // 0 is actually the PIC default for FULL_JITTER
+        pConfig->jitterFactor = (UINT32) env->CallLongMethod(exponentialBackoffConfig, methodId);
+        CHK_JVM_EXCEPTION(env);
+    } else {
+        DLOGW("Couldn't find method id getJitterFactor");
+    }
+
+    DLOGI("Successfully configured exponential backoff: maxRetryCount=%u, maxRetryWaitTime=%llu, retryFactorTime=%llu, jitterType=%u",
+          pConfig->maxRetryCount, pConfig->maxRetryWaitTime, pConfig->retryFactorTime, pConfig->jitterType);
+
+CleanUp:
+    return STATUS_FAILED(retStatus) ? FALSE : TRUE;
+}
 
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount)
 {
@@ -380,6 +585,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
         DLOGW("Couldn't find method id getVersion");
     } else {
         pStreamInfo->version = env->CallIntMethod(streamInfo, methodId);
+        DLOGI("Using StreamInfo version %d", pStreamInfo->version);
         CHK_JVM_EXCEPTION(env);
     }
 

--- a/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/Parameters.cpp
@@ -26,7 +26,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
     // Retrieve the methods and call it
     methodId = env->GetMethodID(cls, "getVersion", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getVersion");
+        DLOGW("Couldn't find method id getVersion. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->version = env->CallIntMethod(deviceInfo, methodId);
         DLOGI("Using DeviceInfo version %d", pDeviceInfo->version);
@@ -35,7 +35,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getName", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getName");
+        DLOGW("Couldn't find method id getName. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -55,7 +55,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getStreamCount", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStreamCount");
+        DLOGW("Couldn't find method id getStreamCount. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->streamCount = env->CallIntMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -63,7 +63,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getStorageInfoVersion", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStorageInfoVersion");
+        DLOGW("Couldn't find method id getStorageInfoVersion. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->storageInfo.version = env->CallIntMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -71,7 +71,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getDeviceStorageType", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getDeviceStorageType");
+        DLOGW("Couldn't find method id getDeviceStorageType. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->storageInfo.storageType = (DEVICE_STORAGE_TYPE) env->CallIntMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -79,7 +79,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getSpillRatio", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getSpillRatio");
+        DLOGW("Couldn't find method id getSpillRatio. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->storageInfo.spillRatio = env->CallIntMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -87,7 +87,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getStorageSize", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStorageSize");
+        DLOGW("Couldn't find method id getStorageSize. Configuration incomplete! Using default.");
     } else {
         pDeviceInfo->storageInfo.storageSize = env->CallLongMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -95,7 +95,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getRootDirectory", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getRootDirectory");
+        DLOGW("Couldn't find method id getRootDirectory. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -116,7 +116,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
     pDeviceInfo->tags = NULL;
     methodId = env->GetMethodID(cls, "getTags", "()[Lcom/amazonaws/kinesisvideo/producer/Tag;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTags");
+        DLOGW("Couldn't find method id getTags. Configuration incomplete! Using default.");
     } else {
         jobjectArray array = (jobjectArray) env->CallObjectMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -131,7 +131,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
 
     methodId = env->GetMethodID(cls, "getClientId", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getClientId");
+        DLOGW("Couldn't find method id getClientId. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -150,7 +150,7 @@ BOOL setDeviceInfo(JNIEnv *env, jobject deviceInfo, PDeviceInfo pDeviceInfo)
     // Set the client info to empty first
     methodId = env->GetMethodID(cls, "getClientInfo", "()Lcom/amazonaws/kinesisvideo/producer/ClientInfo;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getClientInfo");
+        DLOGW("Couldn't find method id getClientInfo. Configuration incomplete! Using default.");
     } else {
         jobject clientInfo = (jobject) env->CallObjectMethod(deviceInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -182,7 +182,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
     // Retrieve the methods and call it
     methodId = env->GetMethodID(cls, "getVersion", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getVersion");
+        DLOGW("Couldn't find method id getVersion. Configuration incomplete! Using default.");
     } else {
         pClientInfo->version = env->CallIntMethod(clientInfo, methodId);
         DLOGI("Using ClientInfo version %d", pClientInfo->version);
@@ -191,7 +191,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getCreateClientTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getCreateClientTimeout");
+        DLOGW("Couldn't find method id getCreateClientTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->createClientTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -199,7 +199,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getCreateStreamTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getCreateStreamTimeout");
+        DLOGW("Couldn't find method id getCreateStreamTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->createStreamTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -207,7 +207,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getStopStreamTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStopStreamTimeout");
+        DLOGW("Couldn't find method id getStopStreamTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->stopStreamTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -215,7 +215,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getOfflineBufferAvailabilityTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getOfflineBufferAvailabilityTimeout");
+        DLOGW("Couldn't find method id getOfflineBufferAvailabilityTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->offlineBufferAvailabilityTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -223,7 +223,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getLoggerLogLevel", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getLoggerLogLevel");
+        DLOGW("Couldn't find method id getLoggerLogLevel. Configuration incomplete! Using default.");
     } else {
         pClientInfo->loggerLogLevel = env->CallIntMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -231,7 +231,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getLogMetric", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getLogMetric");
+        DLOGW("Couldn't find method id getLogMetric. Configuration incomplete! Using default.");
     } else {
         pClientInfo->logMetric = env->CallBooleanMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -242,7 +242,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getMetricLoggingPeriod", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getMetricLoggingPeriod");
+        DLOGW("Couldn't find method id getMetricLoggingPeriod. Configuration incomplete! Using default.");
     } else {
         pClientInfo->metricLoggingPeriod = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -253,7 +253,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getAutomaticStreamingFlags", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getAutomaticStreamingFlags");
+        DLOGW("Couldn't find method id getAutomaticStreamingFlags. Configuration incomplete! Using default.");
     } else {
         pClientInfo->automaticStreamingFlags = (AUTOMATIC_STREAMING_FLAGS) env->CallIntMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -261,7 +261,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getReservedCallbackPeriod", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getReservedCallbackPeriod");
+        DLOGW("Couldn't find method id getReservedCallbackPeriod. Configuration incomplete! Using default.");
     } else {
         pClientInfo->reservedCallbackPeriod = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -269,7 +269,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getKvsRetryStrategy", "()Lcom/amazonaws/kinesisvideo/producer/KvsRetryStrategy;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getKvsRetryStrategy");
+        DLOGW("Couldn't find method id getKvsRetryStrategy. Configuration incomplete! Using default.");
     } else {
         kvsRetryStrategy = (jobject) env->CallObjectMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -284,7 +284,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getServiceConnectionTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getServiceConnectionTimeout");
+        DLOGW("Couldn't find method id getServiceConnectionTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->serviceCallConnectionTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -292,7 +292,7 @@ BOOL setClientInfo(JNIEnv *env, jobject clientInfo, PClientInfo pClientInfo) {
 
     methodId = env->GetMethodID(cls, "getServiceCompletionTimeout", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getServiceCompletionTimeout");
+        DLOGW("Couldn't find method id getServiceCompletionTimeout. Configuration incomplete! Using default.");
     } else {
         pClientInfo->serviceCallCompletionTimeout = env->CallLongMethod(clientInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -343,23 +343,23 @@ BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
 
                 // Convert Java config to native config
                 if (setExponentialBackoffRetryStrategyConfig(env, exponentialBackoffConfig, pNativeConfig)) {
-                    DLOGE("Successfully converted Java config to native config");
+                    DLOGD("Successfully converted Java config to native config");
                 } else {
-                    DLOGE("Failed to convert Java config to native config, using default");
+                    DLOGW("Failed to convert Java config to native config. Configuration incomplete! Using default.");
                     MEMFREE(pNativeConfig);
                     pNativeConfig = NULL;
                 }
             } else {
-                DLOGE("No custom config provided, PIC will use defaults");
+                DLOGI("No custom config provided, PIC will use defaults");
             }
         } else {
-            DLOGE("Couldn't find getExponentialBackoffConfig method");
+            DLOGW("Couldn't find getExponentialBackoffConfig method. Configuration incomplete! Using default.");
         }
     }
 
     // Set the config pointer (NULL means use PIC defaults)
     pKvsRetryStrategy->pRetryStrategyConfig = (PRetryStrategyConfig) pNativeConfig;
-    DLOGE("The retry stratgy config is: %p", pNativeConfig);
+    DLOGD("The retry stratgy config is: %p", pNativeConfig);
 
     // PIC will handle setting pRetryStrategy when the strategy is created
     pKvsRetryStrategy->pRetryStrategy = NULL;
@@ -369,7 +369,7 @@ BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategy, PKvsRetryStrateg
     pCallbacks->executeRetryStrategyFn = getExponentialBackoffRetryStrategyWaitTime;
     pCallbacks->getCurrentRetryAttemptNumberFn = getExponentialBackoffRetryCount;
 
-    DLOGE("Successfully configured retry strategy: type=%d, config=%p",
+    DLOGD("Successfully configured retry strategy: type=%d, config=%p",
           pKvsRetryStrategy->retryStrategyType, pKvsRetryStrategy->pRetryStrategyConfig);
 
 CleanUp:
@@ -397,7 +397,7 @@ BOOL setExponentialBackoffRetryStrategyConfig(JNIEnv *env, jobject exponentialBa
         pConfig->maxRetryCount = env->CallLongMethod(exponentialBackoffConfig, methodId);
         CHK_JVM_EXCEPTION(env);
     } else {
-        DLOGW("Couldn't find method id getMaxRetryCount");
+        DLOGW("Couldn't find method id getMaxRetryCount. Configuration incomplete! Using default.");
     }
 
     // Get maxRetryWaitTime
@@ -445,7 +445,7 @@ BOOL setExponentialBackoffRetryStrategyConfig(JNIEnv *env, jobject exponentialBa
         CHK_JVM_EXCEPTION(env);
         pConfig->jitterType = (javaValue == 0) ? FULL_JITTER : (ExponentialBackoffJitterType) javaValue;
     } else {
-        DLOGW("Couldn't find method id getJitterTypeValue");
+        DLOGW("Couldn't find method id getJitterTypeValue. Configuration incomplete! Using default.");
     }
 
     methodId = env->GetMethodID(cls, "getJitterFactor", "()J");
@@ -454,7 +454,7 @@ BOOL setExponentialBackoffRetryStrategyConfig(JNIEnv *env, jobject exponentialBa
         pConfig->jitterFactor = (UINT32) env->CallLongMethod(exponentialBackoffConfig, methodId);
         CHK_JVM_EXCEPTION(env);
     } else {
-        DLOGW("Couldn't find method id getJitterFactor");
+        DLOGW("Couldn't find method id getJitterFactor. Configuration incomplete! Using default.");
     }
 
     DLOGI("Successfully configured exponential backoff: maxRetryCount=%u, maxRetryWaitTime=%llu, retryFactorTime=%llu, jitterType=%u",
@@ -582,7 +582,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
     // Retrieve the methods and call it
     methodId = env->GetMethodID(cls, "getVersion", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getVersion");
+        DLOGW("Couldn't find method id getVersion. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->version = env->CallIntMethod(streamInfo, methodId);
         DLOGI("Using StreamInfo version %d", pStreamInfo->version);
@@ -591,7 +591,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getName", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getName");
+        DLOGW("Couldn't find method id getName. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -612,7 +612,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getStreamingType", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStreamingType");
+        DLOGW("Couldn't find method id getStreamingType. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.streamingType = (STREAMING_TYPE) env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -620,7 +620,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getContentType", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getContentType");
+        DLOGW("Couldn't find method id getContentType. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -638,7 +638,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getKmsKeyId", "()Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getKmsKeyId");
+        DLOGW("Couldn't find method id getKmsKeyId. Configuration incomplete! Using default.");
     } else {
         jstring retString = (jstring) env->CallObjectMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -656,7 +656,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getRetentionPeriod", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getRetentionPeriod");
+        DLOGW("Couldn't find method id getRetentionPeriod. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->retention = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -664,7 +664,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isAdaptive", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isAdaptive");
+        DLOGW("Couldn't find method id isAdaptive. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.adaptive = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -672,7 +672,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isAllowStreamCreation", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isAllowStreamCreation");
+        DLOGW("Couldn't find method id isAllowStreamCreation. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.allowStreamCreation = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -681,7 +681,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getMaxLatency", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getMaxLatency");
+        DLOGW("Couldn't find method id getMaxLatency. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.maxLatency = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -689,7 +689,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getFragmentDuration", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getFragmentDuration");
+        DLOGW("Couldn't find method id getFragmentDuration. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.fragmentDuration = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -697,7 +697,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isKeyFrameFragmentation", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isKeyFrameFragmentation");
+        DLOGW("Couldn't find method id isKeyFrameFragmentation. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.keyFrameFragmentation = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -705,7 +705,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isFrameTimecodes", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isFrameTimecodes");
+        DLOGW("Couldn't find method id isFrameTimecodes. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.frameTimecodes = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -713,7 +713,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isAbsoluteFragmentTimes", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isAbsoluteFragmentTimes");
+        DLOGW("Couldn't find method id isAbsoluteFragmentTimes. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.absoluteFragmentTimes = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -721,7 +721,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isFragmentAcks", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isFragmentAcks");
+        DLOGW("Couldn't find method id isFragmentAcks. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.fragmentAcks = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -729,7 +729,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isRecoverOnError", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isRecoverOnError");
+        DLOGW("Couldn't find method id isRecoverOnError. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.recoverOnError = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -737,7 +737,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "isRecalculateMetrics", "()Z");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id isRecalculateMetrics");
+        DLOGW("Couldn't find method id isRecalculateMetrics. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.recalculateMetrics = env->CallBooleanMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -745,7 +745,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getNalAdaptationFlags", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getNalAdaptationFlags");
+        DLOGW("Couldn't find method id getNalAdaptationFlags. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.nalAdaptationFlags = env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -755,7 +755,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
     pStreamInfo->streamCaps.segmentUuid = NULL;
     methodId = env->GetMethodID(cls, "getSegmentUuidBytes", "()[B");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getSegmentUuidBytes");
+        DLOGW("Couldn't find method id getSegmentUuidBytes. Configuration incomplete! Using default.");
     } else {
         byteArray = (jbyteArray) env->CallObjectMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -782,7 +782,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTrackInfoCount", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTrackInfoCount");
+        DLOGW("Couldn't find method id getTrackInfoCount. Configuration incomplete! Using default.");
     } else {
         trackInfoCount = (UINT32) env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -796,7 +796,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTrackInfoVersion", "(I)I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTrackInfoVersion");
+        DLOGW("Couldn't find method id getTrackInfoVersion. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             pStreamInfo->streamCaps.trackInfoList[i].version = (UINT64) env->CallIntMethod(streamInfo, methodId, i);
@@ -806,7 +806,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTrackName", "(I)Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTrackName");
+        DLOGW("Couldn't find method id getTrackName. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             jstring retString = (jstring) env->CallObjectMethod(streamInfo, methodId, i);
@@ -826,7 +826,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getCodecId", "(I)Ljava/lang/String;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getCodecId");
+        DLOGW("Couldn't find method id getCodecId. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             jstring retString = (jstring) env->CallObjectMethod(streamInfo, methodId, i);
@@ -846,7 +846,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getCodecPrivateData", "(I)[B");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getCodecPrivateData");
+        DLOGW("Couldn't find method id getCodecPrivateData. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             byteArray = (jbyteArray) env->CallObjectMethod(streamInfo, methodId, i);
@@ -876,7 +876,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTrackInfoType", "(I)I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTrackInfoType");
+        DLOGW("Couldn't find method id getTrackInfoType. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             pStreamInfo->streamCaps.trackInfoList[i].trackType = (MKV_TRACK_INFO_TYPE) env->CallIntMethod(streamInfo, methodId, i);
@@ -886,7 +886,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTrackId", "(I)J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTrackId");
+        DLOGW("Couldn't find method id getTrackId. Configuration incomplete! Using default.");
     } else {
         for(UINT32 i = 0; i < trackInfoCount; ++i) {
             pStreamInfo->streamCaps.trackInfoList[i].trackId = (UINT64) env->CallLongMethod(streamInfo, methodId, i);
@@ -896,7 +896,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getAvgBandwidthBps", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getAvgBandwidthBps");
+        DLOGW("Couldn't find method id getAvgBandwidthBps. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.avgBandwidthBps = env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -904,7 +904,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getFrameRate", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getFrameRate");
+        DLOGW("Couldn't find method id getFrameRate. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.frameRate = env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -912,7 +912,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getBufferDuration", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getBufferDuration");
+        DLOGW("Couldn't find method id getBufferDuration. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.bufferDuration = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -920,7 +920,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getReplayDuration", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getReplayDuration");
+        DLOGW("Couldn't find method id getReplayDuration. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.replayDuration = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -928,7 +928,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getConnectionStalenessDuration", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getConnectionStalenessDuration");
+        DLOGW("Couldn't find method id getConnectionStalenessDuration. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.connectionStalenessDuration = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -936,7 +936,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getTimecodeScale", "()J");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTimecodeScale");
+        DLOGW("Couldn't find method id getTimecodeScale. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.timecodeScale = env->CallLongMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -947,7 +947,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
     pStreamInfo->tags = NULL;
     methodId = env->GetMethodID(cls, "getTags", "()[Lcom/amazonaws/kinesisvideo/producer/Tag;");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getTags");
+        DLOGW("Couldn't find method id getTags. Configuration incomplete! Using default.");
     } else {
         jobjectArray array = (jobjectArray) env->CallObjectMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -959,7 +959,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getFrameOrderMode", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getFrameOrderMode");
+        DLOGW("Couldn't find method id getFrameOrderMode. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.frameOrderingMode = (FRAME_ORDER_MODE) env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);
@@ -967,7 +967,7 @@ BOOL setStreamInfo(JNIEnv* env, jobject streamInfo, PStreamInfo pStreamInfo)
 
     methodId = env->GetMethodID(cls, "getStorePressurePolicy", "()I");
     if (methodId == NULL) {
-        DLOGW("Couldn't find method id getStorePressurePolicy");
+        DLOGW("Couldn't find method id getStorePressurePolicy. Configuration incomplete! Using default.");
     } else {
         pStreamInfo->streamCaps.storePressurePolicy = (CONTENT_STORE_PRESSURE_POLICY) env->CallIntMethod(streamInfo, methodId);
         CHK_JVM_EXCEPTION(env);

--- a/jni/include/com/amazonaws/kinesis/video/producer/jni/ClientRegistry.h
+++ b/jni/include/com/amazonaws/kinesis/video/producer/jni/ClientRegistry.h
@@ -19,6 +19,9 @@ public:
     /// Returns the singleton instance
     static ClientRegistry& getInstance();
 
+    /// Thread-safe retrieval of the number of clients currently in the registry
+    SIZE_T getCurrentNumberClients();
+
     /// Thread-safe addition of a client to the registry
     /// Return: the number of clients in the registry after the addition and the client number
     std::pair<SIZE_T, UINT32> addClient(KinesisVideoClientWrapper* client);

--- a/jni/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
+++ b/jni/include/com/amazonaws/kinesis/video/producer/jni/Parameters.h
@@ -17,4 +17,9 @@ BOOL setStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE* 
 BOOL releaseStreamDataBuffer(JNIEnv* env, jobject dataBuffer, UINT32 offset, PBYTE pBuffer);
 BOOL setTags(JNIEnv *env, jobjectArray tagArray, PTag* ppTags, PUINT32 pTagCount);
 VOID releaseTags(PTag tags);
+BOOL setKvsRetryStrategy(JNIEnv *env, jobject kvsRetryStrategyCallbacks, PKvsRetryStrategy pKvsRetryStrategy, PKvsRetryStrategyCallbacks pCallbacks);
+
+// Helper function to convert Java ExponentialBackoffRetryStrategyConfig to native struct
+BOOL setExponentialBackoffRetryStrategyConfig(JNIEnv *env, jobject exponentialBackoffConfig, PExponentialBackoffRetryStrategyConfig pConfig);
+
 #endif // __KINESIS_VIDEO_PARAMETERS_CONVERSION_H__

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/ClientInfo.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/ClientInfo.java
@@ -15,12 +15,13 @@ public class ClientInfo {
      */
     public static final int CLIENT_INFO_CURRENT_VERSION = 3;
     public static final int DEFAULT_LOG_LEVEL = 4;
+    public static final int LOG_LEVEL_DEBUG = 1;
 
     public static enum AutomaticStreamingFlags {
         AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER(0), AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS(256);
         private final int streamingFlagValue;
 
-        private AutomaticStreamingFlags(int streamingFlagValue) {
+        private AutomaticStreamingFlags(final int streamingFlagValue) {
             this.streamingFlagValue = streamingFlagValue;
         }
 
@@ -30,17 +31,21 @@ public class ClientInfo {
 
     }
 
-    private final int mVersion;
-    private final long mCreateClientTimeout;
-    private final long mCreateStreamTimeout;
-    private final long mStopStreamTimeout;
-    private final long mOfflineBufferAvailabilityTimeout;
-    private final int mLogLevel;
-    private final boolean mLogMetric;
-    private final AutomaticStreamingFlags mAutomaticStreamingFlags;
-    private final long mServiceCallCompletionTimeout;
-    private final long mServiceCallConnectionTimeout;
+    private int mVersion;
+    private long mCreateClientTimeout;
+    private long mCreateStreamTimeout;
+    private long mStopStreamTimeout;
+    private long mOfflineBufferAvailabilityTimeout;
+    private int mLogLevel;
+    private boolean mLogMetric;
+    private AutomaticStreamingFlags mAutomaticStreamingFlags;
+    private long mServiceCallCompletionTimeout;
+    private long mServiceCallConnectionTimeout;
+    private long mMetricLoggingPeriod;
+    private long mReservedCallbackPeriod;
+    private KvsRetryStrategy mKvsRetryStrategy;
 
+    @Deprecated
     public ClientInfo() {
         mVersion = CLIENT_INFO_CURRENT_VERSION;
         mCreateClientTimeout = 0L;
@@ -52,19 +57,35 @@ public class ClientInfo {
         mAutomaticStreamingFlags = AutomaticStreamingFlags.AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER;
         mServiceCallCompletionTimeout = 0L;
         mServiceCallConnectionTimeout = 0L;
+        mMetricLoggingPeriod = 0L;
+        mReservedCallbackPeriod = 0L;
+        mKvsRetryStrategy = null;
     }
 
+    @Deprecated
     public ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
                       final long offlineBufferAvailabilityTimeout, final int logLevel,
                       final boolean logMetric, final long serviceCallCompletionTimeout, final long serviceCallConnectionTimeout) {
         this(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
-                logLevel, logMetric, AutomaticStreamingFlags.AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER, serviceCallCompletionTimeout, serviceCallConnectionTimeout);
+                logLevel, logMetric, AutomaticStreamingFlags.AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER, 
+                serviceCallCompletionTimeout, serviceCallConnectionTimeout, 0L, 0L, null);
     }
 
+    @Deprecated
     public ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
                       final long offlineBufferAvailabilityTimeout, final int logLevel,
                       final boolean logMetric, final AutomaticStreamingFlags flag, final long serviceCallCompletionTimeout,
                       final long serviceCallConnectionTimeout) {
+        this(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, logMetric, flag, serviceCallCompletionTimeout, serviceCallConnectionTimeout, 0L, 0L, null);
+    }
+
+    @Deprecated
+    public ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                      final long offlineBufferAvailabilityTimeout, final int logLevel,
+                      final boolean logMetric, final AutomaticStreamingFlags flag, final long serviceCallCompletionTimeout,
+                      final long serviceCallConnectionTimeout, final long metricLoggingPeriod, 
+                      final long reservedCallbackPeriod, final KvsRetryStrategy kvsRetryStrategy) {
         mVersion = CLIENT_INFO_CURRENT_VERSION;
         mCreateClientTimeout = createClientTimeout;
         mCreateStreamTimeout = createStreamTimeout;
@@ -75,6 +96,87 @@ public class ClientInfo {
         mAutomaticStreamingFlags = flag;
         mServiceCallCompletionTimeout = serviceCallCompletionTimeout;
         mServiceCallConnectionTimeout = serviceCallConnectionTimeout;
+        mMetricLoggingPeriod = metricLoggingPeriod;
+        mReservedCallbackPeriod = reservedCallbackPeriod;
+        mKvsRetryStrategy = kvsRetryStrategy;
+    }
+
+    public static ClientInfo createClientInfoV0(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                                                final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric) {
+        return new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel, logMetric);
+    }
+
+    // V0 constructor
+    private ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                       final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric) {
+        this.mVersion = 0;
+        this.mCreateClientTimeout = createClientTimeout;
+        this.mCreateStreamTimeout = createStreamTimeout;
+        this.mStopStreamTimeout = stopStreamTimeout;
+        this.mOfflineBufferAvailabilityTimeout = offlineBufferAvailabilityTimeout;
+        this.mLogLevel = logLevel;
+        this.mLogMetric = logMetric;
+    }
+
+    public static ClientInfo createClientInfoV1(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                                                final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric, final long metricLoggingPeriod) {
+        return new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel, logMetric, metricLoggingPeriod);
+    }
+
+    // V1 constructor
+    private ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                       final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric,
+                       final long metricLoggingPeriod) {
+        this(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel, logMetric);
+
+        this.mVersion = 1;
+        this.mMetricLoggingPeriod = metricLoggingPeriod;
+    }
+
+    public static ClientInfo createClientInfoV2(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                                                final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric,
+                                                final long metricLoggingPeriod, final AutomaticStreamingFlags automaticStreamingFlags,
+                                                final long reservedCallbackPeriod, KvsRetryStrategy kvsRetryStrategy) {
+        return new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel,
+                logMetric, metricLoggingPeriod, automaticStreamingFlags, reservedCallbackPeriod, kvsRetryStrategy);
+    }
+
+    // V2 constructor
+    private ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                       final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric,
+                       final long metricLoggingPeriod, final AutomaticStreamingFlags automaticStreamingFlags,
+                       final long reservedCallbackPeriod, KvsRetryStrategy kvsRetryStrategy) {
+        this(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel, logMetric);
+
+        this.mVersion = 2;
+        this.mMetricLoggingPeriod = metricLoggingPeriod;
+        this.mAutomaticStreamingFlags = automaticStreamingFlags;
+        this.mReservedCallbackPeriod = reservedCallbackPeriod;
+        this.mKvsRetryStrategy = kvsRetryStrategy;
+    }
+
+    public static ClientInfo createClientInfoV3(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                                                final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric,
+                                                final long metricLoggingPeriod, final AutomaticStreamingFlags automaticStreamingFlags,
+                                                final long reservedCallbackPeriod, final KvsRetryStrategy kvsRetryStrategy,
+                                                final long serviceCallCompletionTimeout, final long serviceCallConnectionTimeout) {
+        return new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel,
+                logMetric, metricLoggingPeriod, automaticStreamingFlags, reservedCallbackPeriod, kvsRetryStrategy,
+                serviceCallCompletionTimeout, serviceCallConnectionTimeout);
+    }
+
+    // V3 constructor
+    private ClientInfo(final long createClientTimeout, final long createStreamTimeout, final long stopStreamTimeout,
+                       final long offlineBufferAvailabilityTimeout, final int logLevel, final boolean logMetric,
+                       final long metricLoggingPeriod, final AutomaticStreamingFlags automaticStreamingFlags,
+                       final long reservedCallbackPeriod, final KvsRetryStrategy kvsRetryStrategy,
+                       final long serviceCallCompletionTimeout, final long serviceCallConnectionTimeout) {
+        this(createClientTimeout, createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout, logLevel, logMetric,
+                metricLoggingPeriod, automaticStreamingFlags, reservedCallbackPeriod, kvsRetryStrategy);
+
+        this.mVersion = 3;
+        this.mServiceCallCompletionTimeout = serviceCallCompletionTimeout;
+        this.mServiceCallConnectionTimeout = serviceCallConnectionTimeout;
     }
 
     @CalledByNativeCode
@@ -114,6 +216,9 @@ public class ClientInfo {
 
     @CalledByNativeCode
     public int getAutomaticStreamingFlags() {
+        if (mAutomaticStreamingFlags == null) {
+            return 0;
+        }
         return mAutomaticStreamingFlags.getStreamingFlagValue();
     }
 
@@ -125,5 +230,17 @@ public class ClientInfo {
     @CalledByNativeCode
     public long getServiceConnectionTimeout() {
         return mServiceCallConnectionTimeout;
+    }
+
+    public long getMetricLoggingPeriod() {
+        return mMetricLoggingPeriod;
+    }
+
+    public long getReservedCallbackPeriod() {
+        return mReservedCallbackPeriod;
+    }
+
+    public KvsRetryStrategy getKvsRetryStrategy() {
+        return mKvsRetryStrategy;
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/DeviceInfo.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/DeviceInfo.java
@@ -23,20 +23,28 @@ public class DeviceInfo {
      */
     public static final int DEVICE_INFO_CURRENT_VERSION = 1;
 
-    private final int mVersion;
-    private final String mName;
-    private final StorageInfo mStorageInfo;
-    private final int mStreamCount;
-    private final Tag[] mTags;
-    private final String mClientId;
-    private final ClientInfo mClientInfo;
+    private int mVersion;
+    private String mName;
+    private StorageInfo mStorageInfo;
+    private int mStreamCount;
+    private Tag[] mTags;
+    private String mClientId;
+    private ClientInfo mClientInfo;
 
+    /**
+     * Use {@link #createDeviceInfoV0} instead.
+     */
+    @Deprecated
     public DeviceInfo(int version, @Nullable final String name, @Nonnull final StorageInfo storageInfo,
             int streamCount, @Nullable final Tag[] tags) {
         this(version, name, storageInfo, streamCount, tags,
                 "JNI " + NativeKinesisVideoProducerJni.EXPECTED_LIBRARY_VERSION, new ClientInfo());
     }
 
+    /**
+     * Use {@link #createDeviceInfoV1} instead.
+     */
+    @Deprecated
     public DeviceInfo(int version, @Nullable final String name, @Nonnull final StorageInfo storageInfo,
                       int streamCount, @Nullable final Tag[] tags, @Nonnull final String clientId,
                       @Nonnull final ClientInfo clientInfo) {
@@ -45,6 +53,36 @@ public class DeviceInfo {
         mTags = tags;
         mVersion = version;
         mStreamCount = streamCount;
+        mClientId = clientId;
+        mClientInfo = clientInfo;
+    }
+
+    public static DeviceInfo createDeviceInfoV0(final String name, final StorageInfo storageInfo,
+                                                final int streamCount, final Tag[] tags) {
+        return new DeviceInfo(name, storageInfo, streamCount, tags);
+    }
+
+    // V0 constructor
+    private DeviceInfo(final String name, final StorageInfo storageInfo,
+                       final int streamCount, final Tag[] tags) {
+        mVersion = 0;
+        mStorageInfo = Preconditions.checkNotNull(storageInfo);
+        mName = name;
+        mTags = tags;
+        mStreamCount = streamCount;
+    }
+
+    public static DeviceInfo createDeviceInfoV1(final String name, final StorageInfo storageInfo, final int streamCount, final Tag[] tags, final String clientId, final ClientInfo clientInfo) {
+        return new DeviceInfo(name, storageInfo, streamCount, tags, clientId, clientInfo);
+    }
+
+    // V1 constructor
+    private DeviceInfo(final String name, final StorageInfo storageInfo,
+                       final int streamCount, final Tag[] tags,
+                       final String clientId, final ClientInfo clientInfo) {
+        this(name, storageInfo, streamCount, tags);
+
+        mVersion = 1;
         mClientId = clientId;
         mClientInfo = clientInfo;
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfig.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfig.java
@@ -1,0 +1,333 @@
+package com.amazonaws.kinesisvideo.producer;
+
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import com.amazonaws.kinesisvideo.util.CalledByNativeCode;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Configuration for exponential backoff retry strategy.
+ * This maps to the native ExponentialBackoffRetryStrategyConfig struct in PIC.
+ * <p>
+ * Use 0 for any parameter to let PIC use its built-in default values.
+ * </p>
+ */
+public class ExponentialBackoffRetryStrategyConfig {
+
+    /**
+     * Jitter types that correspond to the native ExponentialBackoffJitterType enum
+     * <p>
+     * Jitter is added after the calculated wait time. For example for the default configuration in PIC:
+     * </p>
+     * <ol>
+     *     <li>Wait: 1000ms + jitter</li>
+     *     <li>Wait: 2000ms + jitter</li>
+     *     <li>Wait: 4000ms + jitter</li>
+     *     <li>Wait: 8000ms + jitter</li>
+     *     <li>Wait: 16000ms + jitter</li>
+     *     <li>Wait: 16000ms + jitter</li>
+     *     <li>Wait: 16000ms + jitter</li>
+     * </ol>
+     */
+    public enum JitterType {
+        /**
+         * jitter = random number between {@code [0, wait time)}
+         * <p>
+         * This means the calculated wait time can be at most doubled.
+         * </p>
+         */
+        FULL_JITTER(0x01),
+        /**
+         * jitter = random number between {@code [0, jitter factor)}
+         *
+         * @see #jitterFactor
+         */
+        FIXED_JITTER(0x02),
+        /**
+         * jitter = 0
+         */
+        NO_JITTER(0x03);
+
+        private final int value;
+
+        JitterType(final int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
+
+        public static JitterType fromValue(final int value) {
+            for (final JitterType type : values()) {
+                if (type.value == value) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Unknown jitter type: " + value);
+        }
+    }
+
+    // Sentinel value - 0 means "use PIC defaults"
+    public static final long USE_PIC_DEFAULT = 0;
+
+    /**
+     * Max retries before resetting the count back to 0. Allows you to have a "wave" of times.
+     * Use {@link #USE_PIC_DEFAULT} which is equal to KVS_INFINITE_EXPONENTIAL_RETRIES (0) from PIC.
+     */
+    private final long maxRetryCount;
+
+    /**
+     * Maximum retry wait time. Once the retry wait time reaches this value,
+     * subsequent retries will wait for maxRetryWaitTime (plus jitter).
+     */
+    private final long maxRetryWaitTimeMs;
+
+    // Values from PIC, see Include.h
+    public static final long MIN_KVS_MAX_WAIT_TIME_MILLISECONDS = 10000L;
+    public static final long LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS = 25000L;
+
+    /**
+     * Factor for computing the exponential backoff wait time
+     */
+    private final long retryFactorTimeMs;
+
+    // Values from PIC, see Include.h
+    public static final long MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS = 50L;
+    public static final long LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS = 1000L;
+
+    /**
+     * The minimum time between two consecutive retries after which retry state will be reset i.e. retries
+     * will start from initial retry state.
+     */
+    private final long minTimeToResetRetryStateMs;
+
+    // Values from PIC, see Include.h
+    public static final long MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS = 90000L;
+    public static final long LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS = 120000L;
+
+    /**
+     * Jitter type indicating how much jitter to be added
+     * Default will be {@link JitterType#FULL_JITTER}
+     */
+    private final JitterType jitterType;
+
+    /**
+     * Factor determining random jitter value.
+     * Jitter will be between {@code [0, jitterFactor)}.
+     * This parameter is only valid for jitter type {@link JitterType#FIXED_JITTER}
+     */
+    private final long jitterFactor;
+
+    // Values from PIC, see Include.h
+    public static final long MIN_KVS_JITTER_FACTOR_MILLISECONDS = 50L;
+    public static final long LIMIT_KVS_JITTER_FACTOR_MILLISECONDS = 600L;
+
+    @SuppressWarnings("ConstantConditions")
+    public ExponentialBackoffRetryStrategyConfig(@Nonnull final ExponentialBackoffRetryStrategyConfigBuilder builder) {
+        Preconditions.checkArgument(builder != null, "ExponentialBackoffRetryStrategyConfigBuilder builder cannot be null");
+
+        this.maxRetryCount = builder.maxRetryCount;
+        this.maxRetryWaitTimeMs = builder.maxRetryWaitTimeMs;
+        this.retryFactorTimeMs = builder.retryFactorTimeMs;
+        this.minTimeToResetRetryStateMs = builder.minTimeToResetRetryStateMs;
+        this.jitterType = builder.jitterType;
+        this.jitterFactor = builder.jitterFactor;
+    }
+
+    @CalledByNativeCode
+    public long getMaxRetryCount() {
+        return this.maxRetryCount;
+    }
+
+    @CalledByNativeCode
+    public long getMaxRetryWaitTimeMs() {
+        return this.maxRetryWaitTimeMs;
+    }
+
+    @CalledByNativeCode
+    public long getRetryFactorTimeMs() {
+        return this.retryFactorTimeMs;
+    }
+
+    @CalledByNativeCode
+    public long getMinTimeToResetRetryStateMs() {
+        return this.minTimeToResetRetryStateMs;
+    }
+
+    @Nullable
+    public JitterType getJitterType() {
+        return this.jitterType;
+    }
+
+    @CalledByNativeCode
+    public int getJitterTypeValue() {
+        return this.jitterType != null ? this.jitterType.getValue() : (int) USE_PIC_DEFAULT;
+    }
+
+    @CalledByNativeCode
+    public long getJitterFactor() {
+        return this.jitterFactor;
+    }
+
+    @Override
+    public String toString() {
+        return "ExponentialBackoffRetryStrategyConfig{" +
+                "maxRetryCount=" + (this.maxRetryCount == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.maxRetryCount) +
+                ", maxRetryWaitTimeMs=" + (this.maxRetryWaitTimeMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.maxRetryWaitTimeMs) +
+                ", retryFactorTimeMs=" + (this.retryFactorTimeMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.retryFactorTimeMs) +
+                ", minTimeToResetRetryStateMs=" + (this.minTimeToResetRetryStateMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.minTimeToResetRetryStateMs) +
+                ", jitterType=" + (this.jitterType == null ? "PIC_DEFAULT" : this.jitterType) +
+                ", jitterFactor=" + (this.jitterFactor == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.jitterFactor) +
+                '}';
+    }
+
+    public interface MaxRetryCountStep {
+        MaxRetryWaitTimeStep maxRetryCount(final long maxRetryCount);
+    }
+
+    public interface MaxRetryWaitTimeStep {
+        RetryFactorTimeStep maxRetryWaitTimeMs(final long maxRetryWaitTimeMs);
+    }
+
+    public interface RetryFactorTimeStep {
+        MinTimeToResetRetryStateStep retryFactorTimeMs(final long retryFactorTimeMs);
+    }
+
+    public interface MinTimeToResetRetryStateStep {
+        JitterTypeStep minTimeToResetRetryStateMs(final long minTimeToResetRetryStateMs);
+    }
+
+    public interface JitterTypeStep {
+        ExponentialBackoffRetryStrategyConfigBuilder noJitter();
+
+        ExponentialBackoffRetryStrategyConfigBuilder fullJitter();
+
+        JitterFactorStep fixedJitter();
+    }
+
+    public interface JitterFactorStep {
+        ExponentialBackoffRetryStrategyConfigBuilder jitterFactor(final long jitterFactor);
+    }
+
+    public static class ExponentialBackoffRetryStrategyConfigBuilder implements MaxRetryCountStep, MaxRetryWaitTimeStep,
+            RetryFactorTimeStep, MinTimeToResetRetryStateStep, JitterTypeStep, JitterFactorStep {
+        private long maxRetryCount = USE_PIC_DEFAULT;
+        private long maxRetryWaitTimeMs = USE_PIC_DEFAULT;
+        private long retryFactorTimeMs = USE_PIC_DEFAULT;
+        private long minTimeToResetRetryStateMs = USE_PIC_DEFAULT;
+        private JitterType jitterType = null;
+        private long jitterFactor = USE_PIC_DEFAULT;
+
+        private ExponentialBackoffRetryStrategyConfigBuilder() {
+        }
+
+        public static MaxRetryCountStep with() {
+            return new ExponentialBackoffRetryStrategyConfigBuilder();
+        }
+
+        public static ExponentialBackoffRetryStrategyConfig defaults() {
+            return new ExponentialBackoffRetryStrategyConfigBuilder().build();
+        }
+
+        /**
+         * Max retries after which an error will be returned to the application.
+         * For infinite retries, set this to KVS_INFINITE_EXPONENTIAL_RETRIES (0).
+         */
+        @Override
+        public MaxRetryWaitTimeStep maxRetryCount(final long maxRetryCount) {
+            Preconditions.checkArgument(maxRetryCount >= 0, "maxRetryCount cannot be negative");
+            this.maxRetryCount = maxRetryCount;
+            return this;
+        }
+
+        /**
+         * Maximum retry wait time. Once the retry wait time reaches this value,
+         * subsequent retries will wait for maxRetryWaitTime (plus jitter).
+         */
+        @Override
+        public RetryFactorTimeStep maxRetryWaitTimeMs(final long maxRetryWaitTimeMs) {
+            checkInRange(maxRetryWaitTimeMs, MIN_KVS_MAX_WAIT_TIME_MILLISECONDS, LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS);
+            this.maxRetryWaitTimeMs = maxRetryWaitTimeMs;
+            return this;
+        }
+
+        /**
+         * Base factor for computing the exponential backoff wait time.
+         * The formula is: {@code retryFactorTime * 2^retryCount + jitter}
+         */
+        @Override
+        public MinTimeToResetRetryStateStep retryFactorTimeMs(final long retryFactorTimeMs) {
+            checkInRange(retryFactorTimeMs, MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS, LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS);
+            this.retryFactorTimeMs = retryFactorTimeMs;
+            return this;
+        }
+
+        /**
+         * The minimum time between two consecutive retries after which retry state will be reset i.e. retries
+         * will start from initial retry state.
+         */
+        @Override
+        public JitterTypeStep minTimeToResetRetryStateMs(final long minTimeToResetRetryStateMs) {
+            checkInRange(minTimeToResetRetryStateMs, MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS, LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS);
+            this.minTimeToResetRetryStateMs = minTimeToResetRetryStateMs;
+            return this;
+        }
+
+        /**
+         * jitter = 0
+         */
+        @Override
+        public ExponentialBackoffRetryStrategyConfigBuilder noJitter() {
+            this.jitterType = JitterType.NO_JITTER;
+            return this;
+        }
+
+        /**
+         * jitter = random number between {@code [0, calculated wait time)}
+         * <p>
+         * This means the calculated wait time can be at most doubled.
+         * </p>
+         */
+        @Override
+        public ExponentialBackoffRetryStrategyConfigBuilder fullJitter() {
+            this.jitterType = JitterType.FULL_JITTER;
+            return this;
+        }
+
+        /**
+         * Jitter will be between {@code [0, jitterFactor)}.
+         */
+        @Override
+        public JitterFactorStep fixedJitter() {
+            this.jitterType = JitterType.FIXED_JITTER;
+            return this;
+        }
+
+        /**
+         * Jitter will be between {@code [0, jitterFactor)}.
+         */
+        @Override
+        public ExponentialBackoffRetryStrategyConfigBuilder jitterFactor(final long jitterFactor) {
+            checkInRange(jitterFactor, MIN_KVS_JITTER_FACTOR_MILLISECONDS, LIMIT_KVS_JITTER_FACTOR_MILLISECONDS);
+            this.jitterFactor = jitterFactor;
+            return this;
+        }
+
+        public ExponentialBackoffRetryStrategyConfig build() {
+            return new ExponentialBackoffRetryStrategyConfig(this);
+        }
+
+        /**
+         * Checks that {@code value} is either {@link #USE_PIC_DEFAULT} or
+         * between {@code minimum} and {@code maximum} (inclusive).
+         */
+        private void checkInRange(final long value, final long minimum, final long maximum) {
+            Preconditions.checkArgument(
+                    value == USE_PIC_DEFAULT ||
+                            (minimum <= value && value <= maximum)
+                    , value + " must be between " + minimum + " and " + maximum + " (inclusive)");
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfig.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfig.java
@@ -41,7 +41,7 @@ public class ExponentialBackoffRetryStrategyConfig {
         /**
          * jitter = random number between {@code [0, jitter factor)}
          *
-         * @see #jitterFactor
+         * @see #jitterFactorMs
          */
         FIXED_JITTER(0x02),
         /**
@@ -118,7 +118,7 @@ public class ExponentialBackoffRetryStrategyConfig {
      * Jitter will be between {@code [0, jitterFactor)}.
      * This parameter is only valid for jitter type {@link JitterType#FIXED_JITTER}
      */
-    private final long jitterFactor;
+    private final long jitterFactorMs;
 
     // Values from PIC, see Include.h
     public static final long MIN_KVS_JITTER_FACTOR_MILLISECONDS = 50L;
@@ -133,7 +133,7 @@ public class ExponentialBackoffRetryStrategyConfig {
         this.retryFactorTimeMs = builder.retryFactorTimeMs;
         this.minTimeToResetRetryStateMs = builder.minTimeToResetRetryStateMs;
         this.jitterType = builder.jitterType;
-        this.jitterFactor = builder.jitterFactor;
+        this.jitterFactorMs = builder.jitterFactor;
     }
 
     @CalledByNativeCode
@@ -168,7 +168,7 @@ public class ExponentialBackoffRetryStrategyConfig {
 
     @CalledByNativeCode
     public long getJitterFactor() {
-        return this.jitterFactor;
+        return this.jitterFactorMs;
     }
 
     @Override
@@ -179,7 +179,7 @@ public class ExponentialBackoffRetryStrategyConfig {
                 ", retryFactorTimeMs=" + (this.retryFactorTimeMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.retryFactorTimeMs) +
                 ", minTimeToResetRetryStateMs=" + (this.minTimeToResetRetryStateMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.minTimeToResetRetryStateMs) +
                 ", jitterType=" + (this.jitterType == null ? "PIC_DEFAULT" : this.jitterType) +
-                ", jitterFactor=" + (this.jitterFactor == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.jitterFactor) +
+                ", jitterFactor=" + (this.jitterFactorMs == USE_PIC_DEFAULT ? "PIC_DEFAULT" : this.jitterFactorMs) +
                 '}';
     }
 
@@ -208,7 +208,7 @@ public class ExponentialBackoffRetryStrategyConfig {
     }
 
     public interface JitterFactorStep {
-        ExponentialBackoffRetryStrategyConfigBuilder jitterFactor(final long jitterFactor);
+        ExponentialBackoffRetryStrategyConfigBuilder jitterFactorMillis(final long jitterFactor);
     }
 
     public static class ExponentialBackoffRetryStrategyConfigBuilder implements MaxRetryCountStep, MaxRetryWaitTimeStep,
@@ -243,7 +243,7 @@ public class ExponentialBackoffRetryStrategyConfig {
         }
 
         /**
-         * Maximum retry wait time. Once the retry wait time reaches this value,
+         * Maximum retry wait time in milliseconds. Once the retry wait time reaches this value,
          * subsequent retries will wait for maxRetryWaitTime (plus jitter).
          */
         @Override
@@ -254,7 +254,7 @@ public class ExponentialBackoffRetryStrategyConfig {
         }
 
         /**
-         * Base factor for computing the exponential backoff wait time.
+         * Base factor for computing the exponential backoff wait time in milliseconds.
          * The formula is: {@code retryFactorTime * 2^retryCount + jitter}
          */
         @Override
@@ -265,8 +265,8 @@ public class ExponentialBackoffRetryStrategyConfig {
         }
 
         /**
-         * The minimum time between two consecutive retries after which retry state will be reset i.e. retries
-         * will start from initial retry state.
+         * The minimum time, in milliseconds, between two consecutive retries after which retry state will be reset
+         * i.e. retries will start from initial retry state.
          */
         @Override
         public JitterTypeStep minTimeToResetRetryStateMs(final long minTimeToResetRetryStateMs) {
@@ -306,10 +306,11 @@ public class ExponentialBackoffRetryStrategyConfig {
         }
 
         /**
+         * Specify jitterFactor in milliseconds.
          * Jitter will be between {@code [0, jitterFactor)}.
          */
         @Override
-        public ExponentialBackoffRetryStrategyConfigBuilder jitterFactor(final long jitterFactor) {
+        public ExponentialBackoffRetryStrategyConfigBuilder jitterFactorMillis(final long jitterFactor) {
             checkInRange(jitterFactor, MIN_KVS_JITTER_FACTOR_MILLISECONDS, LIMIT_KVS_JITTER_FACTOR_MILLISECONDS);
             this.jitterFactor = jitterFactor;
             return this;

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/KvsRetryStrategy.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/KvsRetryStrategy.java
@@ -12,7 +12,8 @@ import javax.annotation.Nullable;
  * <p>
  * <strong>NOTE:</strong> RetryStrategy only gives control over the retry wait times.
  * The "which errors to retry" and "how many times to retry" is handled
- * by the PIC state machine.
+ * by the PIC state machine. PIC considers it a retry only when moving
+ * from one state into the same state (e.g. DescribeStream->DescribeStream).
  * </p>
  */
 public class KvsRetryStrategy {

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/KvsRetryStrategy.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/KvsRetryStrategy.java
@@ -1,0 +1,139 @@
+package com.amazonaws.kinesisvideo.producer;
+
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
+import com.amazonaws.kinesisvideo.util.CalledByNativeCode;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Configuration class for retry strategy settings.
+ * This maps to the native KvsRetryStrategy struct in PIC.
+ * <p>
+ * <strong>NOTE:</strong> RetryStrategy only gives control over the retry wait times.
+ * The "which errors to retry" and "how many times to retry" is handled
+ * by the PIC state machine.
+ * </p>
+ */
+public class KvsRetryStrategy {
+
+    /**
+     * Corresponds to the native counterpart.
+     */
+    public enum RetryStrategyType {
+        /**
+         * Use the defaults from PIC.
+         */
+        DISABLED(0x00),
+        /**
+         * Use the exponential backoff from PIC.
+         */
+        EXPONENTIAL_BACKOFF_WAIT(0x01);
+
+        private final int value;
+
+        RetryStrategyType(final int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
+
+        public static RetryStrategyType fromValue(final int value) {
+            for (final RetryStrategyType type : values()) {
+                if (type.value == value) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Unknown retry strategy type: " + value);
+        }
+    }
+
+    private final RetryStrategyType retryStrategyType;
+    private final ExponentialBackoffRetryStrategyConfig exponentialBackoffConfig;
+
+    @SuppressWarnings("ConstantConditions")
+    public KvsRetryStrategy(@Nonnull final KvsRetryStrategyBuilder builder) {
+        Preconditions.checkArgument(builder != null, "KvsRetryStrategy builder cannot be null!");
+
+        this.retryStrategyType = builder.retryStrategyType;
+        this.exponentialBackoffConfig = builder.exponentialBackoffConfig;
+    }
+
+    public RetryStrategyType getRetryStrategyType() {
+        return this.retryStrategyType;
+    }
+
+    @CalledByNativeCode
+    public int getRetryStrategyTypeValue() {
+        return getRetryStrategyType().getValue();
+    }
+
+    @CalledByNativeCode
+    public ExponentialBackoffRetryStrategyConfig getExponentialBackoffConfig() {
+        return this.exponentialBackoffConfig;
+    }
+
+    public interface RetryStrategyTypeStep {
+        /**
+         * Using {@link RetryStrategyType#DISABLED}.
+         */
+        KvsRetryStrategyBuilder disabled();
+
+        /**
+         * Using {@link RetryStrategyType#EXPONENTIAL_BACKOFF_WAIT}.
+         */
+        RetryStrategyConfigStep exponentialBackoff();
+    }
+
+    public interface RetryStrategyConfigStep {
+        KvsRetryStrategyBuilder config(ExponentialBackoffRetryStrategyConfig exponentialBackoffConfig);
+    }
+
+    public static class KvsRetryStrategyBuilder implements RetryStrategyTypeStep, RetryStrategyConfigStep {
+        @Nonnull
+        private RetryStrategyType retryStrategyType = RetryStrategyType.DISABLED;
+        @Nullable
+        private ExponentialBackoffRetryStrategyConfig exponentialBackoffConfig = null;
+
+        private KvsRetryStrategyBuilder() {
+        }
+
+        public static RetryStrategyTypeStep with() {
+            return new KvsRetryStrategyBuilder();
+        }
+
+        public static KvsRetryStrategy defaults() {
+            return new KvsRetryStrategyBuilder().build();
+        }
+
+        /**
+         * Use the PIC defaults for the retry wait time calculations.
+         */
+        @Override
+        public KvsRetryStrategyBuilder disabled() {
+            this.retryStrategyType = RetryStrategyType.DISABLED;
+            return this;
+        }
+
+        /**
+         * Use the exponential backoff for the retry wait time calculations.
+         */
+        @Override
+        public RetryStrategyConfigStep exponentialBackoff() {
+            this.retryStrategyType = RetryStrategyType.EXPONENTIAL_BACKOFF_WAIT;
+            return this;
+        }
+
+        @Override
+        public KvsRetryStrategyBuilder config(@Nullable final ExponentialBackoffRetryStrategyConfig exponentialBackoffConfig) {
+            this.exponentialBackoffConfig = exponentialBackoffConfig;
+            return this;
+        }
+
+        public KvsRetryStrategy build() {
+            return new KvsRetryStrategy(this);
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/common/DeviceInfoClientInfoVersionTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/DeviceInfoClientInfoVersionTest.java
@@ -1,0 +1,296 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.producer.ClientInfo;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.KvsRetryStrategy;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.nio.ByteBuffer;
+
+import static com.amazonaws.kinesisvideo.producer.ProducerException.STATUS_SUCCESS;
+import static com.amazonaws.kinesisvideo.producer.Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * These tests check the struct migration/versioning pattern used in PIC.
+ * <ul>
+ *     <li>{@link DeviceInfo} is the main parameter object for configuring the KVS Producer client.</li>
+ *     <li>The v0 of the struct has a few members</li>
+ *     <li>The v1 of the struct has a couple new members, in particular, the {@link ClientInfo} parameter,
+ *     which also has multiple struct versions on its own</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/awslabs/amazon-kinesis-video-streams-pic">Amazon Kinesis Video Streams PIC</a>
+ */
+public class DeviceInfoClientInfoVersionTest extends ProducerTestBase {
+
+    private static final int STORAGE_INFO_VERSION_ZERO = 0;
+    private static final int ONE_SECOND_HUNDREDS_OF_NANOS = 1000 * 10000;
+    private static final int TEN_SECONDS_HUNDREDS_OF_NANOS = 10 * ONE_SECOND_HUNDREDS_OF_NANOS;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(15);
+
+    private StorageInfo storageInfo;
+
+    @Before
+    public void setUp() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+
+        final long storageSizeBytes = 10 * 1024 * 1024; // 10 MiB
+        final int spillRatioPercent = 90;
+        final String rootDirectory = "/tmp";
+
+        this.storageInfo = new StorageInfo(STORAGE_INFO_VERSION_ZERO,
+                StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM, storageSizeBytes,
+                spillRatioPercent, rootDirectory);
+    }
+
+    // Note: Suppressing the warnings to make the code more readable since the code uses long parameter lists
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void test_deviceInfo_v0_constructor_works() throws ProducerException {
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+
+        final DeviceInfo deviceInfo = DeviceInfo.createDeviceInfoV0(deviceName, this.storageInfo, streamCount, tags);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        testStreaming(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions", "ExtractMethodRecommender"})
+    public void test_deviceInfo_v1_constructor_with_clientInfo_v0() throws ProducerException {
+
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.LOG_LEVEL_DEBUG;
+        final boolean doLogMetrics = true;
+
+        final ClientInfo clientInfo = ClientInfo.createClientInfoV0(createClientTimeout,
+                createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, doLogMetrics);
+
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String clientId = String.format("ProducerJava-%s-%s", this.getClass().getSimpleName(), methodName);
+
+        final DeviceInfo deviceInfo = DeviceInfo.createDeviceInfoV1(deviceName, this.storageInfo, streamCount, tags,
+                clientId, clientInfo);
+
+        createProducer(deviceInfo);
+
+        testStreaming(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions", "ExtractMethodRecommender"})
+    public void test_deviceInfo_v1_constructor_with_clientInfo_v1() throws ProducerException {
+
+        // ClientInfo V0 fields
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.DEFAULT_LOG_LEVEL;
+        final boolean doLogMetrics = true;
+
+        // ClientInfo V1 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        final ClientInfo clientInfo = ClientInfo.createClientInfoV1(createClientTimeout,
+                createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, doLogMetrics, metricsLoggingPeriod);
+
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String clientId = String.format("ProducerJava-%s-%s", this.getClass().getSimpleName(), methodName);
+
+        final DeviceInfo deviceInfo = DeviceInfo.createDeviceInfoV1(deviceName, this.storageInfo, streamCount, tags,
+                clientId, clientInfo);
+
+        createProducer(deviceInfo);
+
+        testStreaming(methodName);
+
+        free();
+    }
+
+    @Test
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions", "ExtractMethodRecommender"})
+    public void test_deviceInfo_v1_constructor_with_clientInfo_v2() throws ProducerException {
+
+        // ClientInfo V0 fields
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.DEFAULT_LOG_LEVEL;
+
+        // ClientInfo V1 fields
+        final boolean doLogMetrics = true;
+
+        // ClientInfo V2 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final ClientInfo.AutomaticStreamingFlags automaticStreamingFlags = null;
+        final long reservedCallbackPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final KvsRetryStrategy kvsRetryStrategy = null;
+
+        final ClientInfo clientInfo = ClientInfo.createClientInfoV2(createClientTimeout,
+                createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, doLogMetrics, metricsLoggingPeriod, automaticStreamingFlags,
+                reservedCallbackPeriod, kvsRetryStrategy);
+
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String clientId = String.format("ProducerJava-%s-%s", this.getClass().getSimpleName(), methodName);
+
+        final DeviceInfo deviceInfo = DeviceInfo.createDeviceInfoV1(deviceName, this.storageInfo, streamCount, tags,
+                clientId, clientInfo);
+
+        createProducer(deviceInfo);
+
+        testStreaming(methodName);
+
+        free();
+    }
+
+    @Test
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions", "ExtractMethodRecommender"})
+    public void test_deviceInfo_v1_constructor_with_clientInfo_v3() throws ProducerException {
+
+        // ClientInfo V0 fields
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.DEFAULT_LOG_LEVEL;
+
+        // ClientInfo V1 fields
+        final boolean doLogMetrics = true;
+
+        // ClientInfo V2 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final ClientInfo.AutomaticStreamingFlags automaticStreamingFlags = null;
+        final long reservedCallbackPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final KvsRetryStrategy kvsRetryStrategy = null;
+
+        // ClientInfo V3 fields
+        final long serviceCallCompletionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long serviceCallConnectionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        final ClientInfo clientInfo = ClientInfo.createClientInfoV3(createClientTimeout,
+                createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, doLogMetrics, metricsLoggingPeriod, automaticStreamingFlags,
+                reservedCallbackPeriod, kvsRetryStrategy,
+                serviceCallCompletionTimeout, serviceCallConnectionTimeout);
+
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String clientId = String.format("ProducerJava-%s-%s", this.getClass().getSimpleName(), methodName);
+
+        final DeviceInfo deviceInfo = DeviceInfo.createDeviceInfoV1(deviceName, this.storageInfo, streamCount, tags,
+                clientId, clientInfo);
+
+        createProducer(deviceInfo);
+
+        testStreaming(methodName);
+
+        free();
+    }
+
+    @SuppressWarnings({"UnnecessaryLocalVariable"})
+    private void testStreaming(final String methodName) throws ProducerException {
+        final String streamName = "DeviceInfoClientInfoVersionTest-" + methodName + "-" + System.currentTimeMillis();
+        final StreamInfo.StreamingType streamingType = StreamInfo.StreamingType.STREAMING_TYPE_REALTIME;
+        final long maxLatency = TEN_SECONDS_HUNDREDS_OF_NANOS;
+        final long bufferDuration = TEN_SECONDS_HUNDREDS_OF_NANOS;
+
+        final KinesisVideoProducerStream stream = createTestStream(streamName, streamingType, maxLatency, bufferDuration);
+
+        final long now = System.currentTimeMillis();
+        final int fps = 10;
+        final int durationSec = 3;
+        final int keyFrameIntervalSec = 1;
+
+        // Stream durationSec seconds ago until now
+        for (int index = 0; index < durationSec * fps; index++) {
+            final int flags = index % (keyFrameIntervalSec * fps) == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+            final long frameDurationMs = 1000 / fps;
+            final long timestampMs = now - (durationSec * 1000) + index * frameDurationMs;
+            final long dtsPtsHundredsOfNanos = timestampMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+            final byte[] mockData = new byte[]{1, 2, 3, 4};
+            final KinesisVideoFrame testFrame = new KinesisVideoFrame(index, flags,
+                    dtsPtsHundredsOfNanos, dtsPtsHundredsOfNanos,
+                    1000 / fps * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, ByteBuffer.wrap(mockData));
+            try {
+                stream.putFrame(testFrame);
+
+                Thread.sleep(frameDurationMs);
+            } catch (final Exception e) {
+                e.printStackTrace();
+                fail("Failed to put the frames into the stream! " + e.getMessage());
+            }
+        }
+        try {
+            Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
+        } catch (final InterruptedException e) {
+            e.printStackTrace();
+            fail();
+        }
+
+        // frameDropped_ is set to false initially. It can be set to true by droppedFrameReport callback in case there
+        // was a frame that was dropped during the test
+        assertFalse(this.frameDropped_);
+        // errorStatus_ is set to STATUS_SUCCESS initially. It can be set to a different statusCode by
+        // streamErrorReport callback in case an error is encountered during the test
+        assertEquals(STATUS_SUCCESS, this.errorStatus_);
+        // bufferingAckInSequence_ is true initially. It can be set to false by fragmentAckReceived callback in case the
+        // (current timestamp - previous timestamp of the ack) > fragment duration
+        assertTrue(this.bufferingAckInSequence_);
+
+        freeTestStream(stream);
+
+        deleteStream(streamName);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/common/EndOfFragmentIntegTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/EndOfFragmentIntegTest.java
@@ -165,7 +165,7 @@ public class EndOfFragmentIntegTest extends ProducerTestBase {
 
         assertFalse("An exception happened during cleanup!", failure);
 
-        freeProducer();
+        free();
 
         // Verify that all the threads are shut down and there are no thread leaks
         this.threadWatcher.close();

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerApiTest.java
@@ -36,7 +36,7 @@ public class ProducerApiTest extends ProducerTestBase{
      * and, re-create them
      */
     @Test
-    public void createFreeStream() {
+    public void createFreeStream() throws ProducerException {
         KinesisVideoProducerStream [] kinesisVideoProducerStreams = new KinesisVideoProducerStream[TEST_STREAM_COUNT];
         createProducer();
         String testStreamName;
@@ -70,7 +70,7 @@ public class ProducerApiTest extends ProducerTestBase{
      * This test attempts to create multiple streams, sends frame across them and ultimately stop successfully
      */
     @Test
-    public void createProduceStartStopStream() {
+    public void createProduceStartStopStream() throws ProducerException {
         KinesisVideoProducerStream [] kinesisVideoProducerStreams = new KinesisVideoProducerStream[TEST_STREAM_COUNT];
         KinesisVideoFrame frame;
         String testStreamName;
@@ -133,7 +133,7 @@ public class ProducerApiTest extends ProducerTestBase{
      * caching the stream-endpoint
      */
     @Test
-    public void createProduceStartStopStreamEndpointCached() {
+    public void createProduceStartStopStreamEndpointCached() throws ProducerException {
         KinesisVideoProducerStream [] kinesisVideoProducerStreams = new KinesisVideoProducerStream[TEST_STREAM_COUNT];
         KinesisVideoFrame frame;
         String testStreamName;
@@ -205,7 +205,7 @@ public class ProducerApiTest extends ProducerTestBase{
      * caching the stream-endpoint, credentials-provider and, stream-info
      */
     @Test
-    public void createProduceStartStopStreamAllCached() {
+    public void createProduceStartStopStreamAllCached() throws ProducerException {
         KinesisVideoProducerStream [] kinesisVideoProducerStreams = new KinesisVideoProducerStream[TEST_STREAM_COUNT];
         KinesisVideoFrame frame;
         String testStreamName;

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerFunctionalityTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerFunctionalityTest.java
@@ -36,7 +36,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      * This test creates a stream, stops it and frees it
      */
     @Test
-    public void startStopSyncTerminate() {
+    public void startStopSyncTerminate() throws ProducerException {
         final KinesisVideoProducerStream kinesisVideoProducerStream;
 
         storageInfo_ = new StorageInfo(0,
@@ -63,7 +63,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      * or any buffering acks that are not in sequence.
      */
     @Test
-    public void offlineUploadLimitedBufferDuration() {
+    public void offlineUploadLimitedBufferDuration() throws ProducerException {
         int flags;
         long currentTimeMs = 0;
         final byte[][] framesData = new byte[][]{
@@ -135,7 +135,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      */
     @Ignore
     @Test
-    public void offlineUploadLimitedStorage() {
+    public void offlineUploadLimitedStorage() throws ProducerException {
         int flags;
         long currentTimeMs = System.currentTimeMillis() * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
         final byte[][] framesData = new byte[][]{
@@ -199,7 +199,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      * This test pauses on the last frame of each clip for pauseSeconds which is less than the timeout
      */
     @Test
-    public void intermittentFileUpload() {
+    public void intermittentFileUpload() throws ProducerException {
         int flags;
         long currentTimeMs = 0;
         final byte[][] framesData = new byte[][]{
@@ -285,7 +285,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      */
     @Ignore
     @Test
-    public void highFragmentRateFileUpload() {
+    public void highFragmentRateFileUpload() throws ProducerException {
         int flags;
         long currentTimeMs = 0;
         final byte[][] framesData = new byte[][]{
@@ -352,7 +352,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      */
     @Ignore
     @Test
-    public void offlineModeTokenRotationBlockOnSpace() {
+    public void offlineModeTokenRotationBlockOnSpace() throws ProducerException {
         final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
@@ -419,7 +419,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      * The new session will not roll back as the previous one was closed with a persisted ACK received.
      */
     @Test
-    public void realtimeIntermittentNoLatencyPressureEofr() {
+    public void realtimeIntermittentNoLatencyPressureEofr() throws ProducerException {
         final KinesisVideoProducerStream kinesisVideoProducerStream;
         KinesisVideoFrame frame;
 
@@ -512,7 +512,7 @@ public class ProducerFunctionalityTest extends ProducerTestBase{
      * This test is tests Intermittent Producer under latency pressure
      */
     @Test
-    public void realtimeAutoIntermittentLatencyPressure() {
+    public void realtimeAutoIntermittentLatencyPressure() throws ProducerException {
         final KinesisVideoProducerStream kinesisVideoProducerStream;
 
         final int totalFrameCount;

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
@@ -1,5 +1,7 @@
 package com.amazonaws.kinesisvideo.common;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,9 +18,12 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.kinesisvideo.auth.DefaultAuthCallbacks;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
+import com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks;
+import com.amazonaws.kinesisvideo.internal.producer.client.KinesisVideoServiceClient;
 import com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni;
 import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsFactory;
 import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
@@ -129,6 +134,16 @@ public class ProducerTestBase {
         return keyFrameInterval_ * frameDuration_ / Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     }
 
+    @FunctionalInterface
+    protected interface ServiceCallbacksConstructor {
+        DefaultServiceCallbacksImpl apply(
+                Logger log,
+                ScheduledExecutorService executor,
+                KinesisVideoClientConfiguration configuration,
+                KinesisVideoServiceClient kinesisVideoServiceClient
+        );
+    }
+
     /**
      * This method is used to create a KinesisVideoProducer which is used by the later methods
      */
@@ -137,13 +152,28 @@ public class ProducerTestBase {
                 DEVICE_NAME, storageInfo_, NUMBER_OF_STREAMS, null,
                 "JNI " + NativeKinesisVideoProducerJni.EXPECTED_LIBRARY_VERSION,
                 new ClientInfo());
-        createProducer(deviceInfo_);
+
+        try {
+            createProducer(deviceInfo_);
+        } catch (Exception e) {
+            log.error("Unable to create Kinesis Video Producer.", e);
+            fail("Unable to create Kinesis Video Producer.");
+        }
+    }
+
+    protected void createProducer(DeviceInfo deviceInfo) {
+        try {
+            createProducer(deviceInfo, DefaultServiceCallbacksImpl::new);
+        } catch (Exception e) {
+            log.error("Unable to create Kinesis Video Producer.", e);
+            fail("Unable to create Kinesis Video Producer.");
+        }
     }
 
     /**
      * This method is used to create a KinesisVideoProducer which is used by the later methods
      */
-    protected void createProducer(DeviceInfo deviceInfo) {
+    protected void createProducer(DeviceInfo deviceInfo, ServiceCallbacksConstructor serviceCallbacksConstructor) throws Exception {
 
         reset(); // reset all flags to initial values so that they can be modified by the stream and storage callbacks
 
@@ -166,7 +196,8 @@ public class ProducerTestBase {
         storageCallbacks = new TestStorageCallbacks(this);
         streamCallbacks = new TestStreamCallBacks(this);
 
-        DefaultServiceCallbacksImpl defaultServiceCallbacks = new DefaultServiceCallbacksImpl(log, executor,
+        // Use the custom service callbacks (used to inject return values for API calls)
+        ServiceCallbacks defaultServiceCallbacks = serviceCallbacksConstructor.apply(log, executor,
                 configuration, serviceClient);
         kinesisVideoClient = new NativeKinesisVideoClient(log,
                 authCallbacks,
@@ -210,19 +241,22 @@ public class ProducerTestBase {
      * @return KinesisVideoProducerStream the created stream
      */
     protected KinesisVideoProducerStream createTestStream(String streamName, StreamInfo.StreamingType streamingType,
-                                                          long maxLatency, long bufferDuration) {
-        return createTestStream(streamName, streamingType, maxLatency, bufferDuration, NAL_ADAPTATION_FLAG_NONE);
+                                                          long maxLatency, long bufferDuration) throws ProducerException {
+        return createTestStream(streamName, streamingType, maxLatency, bufferDuration, NAL_ADAPTATION_FLAG_NONE, false);
     }
 
     protected KinesisVideoProducerStream createTestStream(String streamName, StreamInfo.StreamingType streamingType,
-                                                          long maxLatency, long bufferDuration, StreamInfo.NalAdaptationFlags nalAdaptationFlags) {
+                                                          long maxLatency, long bufferDuration, StreamInfo.NalAdaptationFlags nalAdaptationFlags, boolean skipPreparation) throws ProducerException {
         KinesisVideoProducerStream kinesisVideoProducerStream = null;
         
         final byte[] codecPrivateData = ProducerTestCPDs.getTestCPD(nalAdaptationFlags);
 
         final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
         final String finalStreamName = prefix + streamName;
-        prepareStream(finalStreamName);
+
+        if (!skipPreparation) {
+            prepareStream(finalStreamName);
+        }
 
         final StreamInfo streamInfo = new StreamInfo(
                 StreamInfo.STREAM_INFO_CURRENT_VERSION,
@@ -256,14 +290,7 @@ public class ProducerTestBase {
                 allowStreamCreation
         );
 
-        try {
-            kinesisVideoProducerStream = kinesisVideoProducer.createStreamSync(streamInfo, streamCallbacks);
-
-        } catch (final Exception e) {
-            log.error("Failed to create the stream: {}", finalStreamName, e);
-            fail();
-        }
-        return kinesisVideoProducerStream;
+        return kinesisVideoProducer.createStreamSync(streamInfo, streamCallbacks);
     }
 
     /**
@@ -363,6 +390,24 @@ public class ProducerTestBase {
         } catch (ProducerException e) {
             e.printStackTrace();
             fail();
+        }
+    }
+
+    protected void deleteStream(final String streamName) {
+        final AmazonKinesisVideo awsSdkKinesisVideoClient = AmazonKinesisVideoClient.builder().build();
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        final String finalStreamName = prefix + streamName;
+        try {
+            final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest().withStreamName(finalStreamName);
+            final DescribeStreamResult describeStreamResult = awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+
+            final DeleteStreamRequest deleteStreamRequest = new DeleteStreamRequest()
+                    .withStreamARN(describeStreamResult.getStreamInfo().getStreamARN())
+                    .withCurrentVersion(describeStreamResult.getStreamInfo().getVersion());
+            awsSdkKinesisVideoClient.deleteStream(deleteStreamRequest);
+        } catch (final Exception e) {
+            log.error("Failed to delete the stream: {}", finalStreamName, e);
+            fail(e.getMessage());
         }
     }
 

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
@@ -212,7 +212,7 @@ public class ProducerTestBase {
         }
     }
 
-    protected void freeProducer() {
+    protected void free() {
         try {
             this.kinesisVideoProducer.free();
         } catch (ProducerException e) {

--- a/src/test/java/com/amazonaws/kinesisvideo/common/PutFrameNalAdaptionFlagsTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/PutFrameNalAdaptionFlagsTest.java
@@ -59,7 +59,7 @@ public class PutFrameNalAdaptionFlagsTest extends ProducerTestBase {
      * <p>See KinesisVideoClientWrapper.cpp in the JNI.</p>
      */
     @Test
-    public void when_putFrameWithNullByteBufferData_then_exceptionIsThrown() {
+    public void when_putFrameWithNullByteBufferData_then_exceptionIsThrown() throws ProducerException {
         final KinesisVideoProducerStream kinesisVideoProducerStream;
         final String testStreamName = "JavaProducerApiTestStream_when_putFrameWithNullByteBufferData_then_exceptionIsThrown";
 
@@ -67,7 +67,8 @@ public class PutFrameNalAdaptionFlagsTest extends ProducerTestBase {
 
         // Create a test stream with the appropriate NAL adaptation flag
         kinesisVideoProducerStream = createTestStream(testStreamName,
-                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME, TEST_LATENCY, TEST_BUFFER_DURATION, this.nalAdaptationFlags);
+                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME, TEST_LATENCY, TEST_BUFFER_DURATION, this.nalAdaptationFlags,
+                false);
 
         // Create a non-direct ByteBuffer which will cause JNI to return null when calling GetDirectBufferAddress
         final ByteBuffer nonDirectBuffer = ByteBuffer.allocate(10);

--- a/src/test/java/com/amazonaws/kinesisvideo/common/RetryStrategyIntegTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/RetryStrategyIntegTest.java
@@ -1,0 +1,438 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni;
+import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.producer.ClientInfo;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.KvsRetryStrategy;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamDescription;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.kinesisvideo.util.LogCaptureRule;
+import com.amazonaws.kinesisvideo.util.StreamInfoConstants;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static com.amazonaws.kinesisvideo.producer.ProducerException.STATUS_SUCCESS;
+import static com.amazonaws.kinesisvideo.producer.Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * These tests verify the client's retry strategy configuration through the JNI to PIC.
+ * The tests create a client with the specified retry strategy, and verifies that the retry strategy is
+ * accepted and the configuration values are used by PIC.
+ *
+ * @see <a href="https://github.com/awslabs/amazon-kinesis-video-streams-pic">Amazon Kinesis Video Streams PIC</a>
+ */
+public class RetryStrategyIntegTest extends ProducerTestBase {
+
+    private static final Logger log = LogManager.getLogger(RetryStrategyIntegTest.class);
+
+    private static final int STORAGE_INFO_VERSION_ZERO = 0;
+    private static final int ONE_SECOND_HUNDREDS_OF_NANOS = 1000 * 10000;
+    private static final int TEN_SECONDS_HUNDREDS_OF_NANOS = 10 * ONE_SECOND_HUNDREDS_OF_NANOS;
+
+    private static final long STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED = 0x4000002B;
+    private static final long STATUS_DESCRIBE_STREAM_CALL_FAILED = 0x52000011L;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
+
+    @Rule
+    public LogCaptureRule logCapture = new LogCaptureRule();
+
+    private StorageInfo storageInfo;
+
+    @Before
+    public void setUp() throws Exception {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+
+        final long storageSizeBytes = 10 * 1024 * 1024; // 10 MiB
+        final int spillRatioPercent = 90;
+        final String rootDirectory = "/tmp";
+
+        this.deviceInfo_ = new DeviceInfo(DEVICE_VERSION,
+                DEVICE_NAME, this.storageInfo_, NUMBER_OF_STREAMS, null,
+                "JNI " + NativeKinesisVideoProducerJni.EXPECTED_LIBRARY_VERSION,
+                new ClientInfo());
+
+        this.storageInfo = new StorageInfo(STORAGE_INFO_VERSION_ZERO,
+                StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM, storageSizeBytes,
+                spillRatioPercent, rootDirectory);
+    }
+
+    @After
+    public void tearDown() {
+        // LogCaptureRule handles cleanup automatically
+    }
+
+    /**
+     * Using {@link DefaultServiceCallbacksImpl}, except that
+     * {@link com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks#describeStream}
+     * always returns {@value StreamInfoConstants#HTTP_BAD_REQUEST}.
+     */
+    protected void createDescribeStreamErroredProducer(final DeviceInfo deviceInfo) {
+        final ServiceCallbacksConstructor alwaysErroredDescribeStreamServiceCallbacks = (log, executor, configuration, kinesisVideoServiceClient) -> new DefaultServiceCallbacksImpl(log, executor, configuration, kinesisVideoServiceClient) {
+            @Override
+            @SuppressWarnings("ConstantConditions")
+            public void describeStream(@Nonnull final String streamName,
+                                       final long callAfter, final long timeout,
+                                       @Nullable final byte[] authData,
+                                       final int authType, final long streamHandle,
+                                       final KinesisVideoProducerStream stream) throws ProducerException {
+
+                final StreamDescription streamDescription = null;
+                this.log.info("{} - alwaysErroredDescribeStreamCallbacks returning {}", streamName, StreamInfoConstants.HTTP_BAD_REQUEST);
+                this.kinesisVideoProducer.describeStreamResult(stream, streamHandle, streamDescription, StreamInfoConstants.HTTP_BAD_REQUEST);
+            }
+        };
+
+        try {
+            createProducer(deviceInfo, alwaysErroredDescribeStreamServiceCallbacks);
+        } catch (final Exception e) {
+            log.error("Unable to create Kinesis Video Producer.", e);
+            fail(e.getMessage());
+        }
+    }
+
+
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions"})
+    private ClientInfo createClientInfoV2WithRetryStrategy(final KvsRetryStrategy retryStrategy) {
+        // ClientInfo V0 fields
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = TEN_SECONDS_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.LOG_LEVEL_DEBUG;
+
+        // ClientInfo V1 fields
+        final boolean doLogMetrics = false;
+
+        // ClientInfo V2 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final ClientInfo.AutomaticStreamingFlags automaticStreamingFlags = null;
+        final long reservedCallbackPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final KvsRetryStrategy kvsRetryStrategy = retryStrategy;
+
+        return ClientInfo.createClientInfoV2(createClientTimeout,
+                createStreamTimeout, stopStreamTimeout, offlineBufferAvailabilityTimeout,
+                logLevel, doLogMetrics, metricsLoggingPeriod, automaticStreamingFlags,
+                reservedCallbackPeriod, kvsRetryStrategy);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private DeviceInfo createDeviceInfoV1(final ClientInfo clientInfo) {
+        final String deviceName = "java-test-application";
+        final int streamCount = 10;
+        final Tag[] tags = null;
+        final String clientId = String.format("ProducerJava-%s-%s", this.getClass().getSimpleName(),
+                new Object() {
+                }.getClass().getEnclosingMethod().getName());
+
+        return DeviceInfo.createDeviceInfoV1(deviceName, this.storageInfo, streamCount, tags,
+                clientId, clientInfo);
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void givenNullRetryStrategy_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final KvsRetryStrategy kvsRetryStrategy = null;
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void givenDefaultRetryStrategy_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.defaults();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void givenDisabledRetryStrategy_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.with()
+                .disabled()
+                .build();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void givenExponentialBackoffRetryStrategy_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.with()
+                .exponentialBackoff()
+                .config(null)
+                .build();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    public void givenRetryStrategyWithPicDefaults_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final ExponentialBackoffRetryStrategyConfig exponentialBackoffStrategyConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.defaults();
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.with()
+                .exponentialBackoff()
+                .config(exponentialBackoffStrategyConfig)
+                .build();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    @Test
+    @SuppressWarnings({"ConstantConditions"})
+    public void givenCustomConfiguredRetryStrategy_whenCreatingProducer_thenStreamingSucceeds() throws ProducerException {
+
+        final long maxRetryCount = 100;
+        final long maxRetryWaitTimeMs = 20000;
+        final long retryFactorTimeMs = 1000;
+        final long minTimeToResetRetryStateMs = 100005;
+
+        final ExponentialBackoffRetryStrategyConfig config = ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                .maxRetryCount(maxRetryCount)
+                .maxRetryWaitTimeMs(maxRetryWaitTimeMs)
+                .retryFactorTimeMs(retryFactorTimeMs)
+                .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
+                .noJitter()
+                .build();
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.with()
+                .exponentialBackoff()
+                .config(config)
+                .build();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        streamNormally(methodName);
+
+        free();
+
+    }
+
+    /**
+     * This test validates that the custom configuration is actually used by the native code.
+     * <p>
+     * Note: The maxRetryCount currently tells PIC when to reset the internal retry count for the backoff
+     * calculations. If the state machine has infinite retries configured for this state, the calculated
+     * times will be in a wave pattern with a period of maxRetryCount.
+     * </p>
+     */
+    @Test
+    @SuppressWarnings({"ConstantConditions"})
+    public void givenLowMaxRetryCount_whenStreamCreationFails_thenRetryExhaustionIsLogged() throws ProducerException {
+
+        final long maxRetryCount = 1;
+        final long maxRetryWaitTimeMs = 10000;
+        final long retryFactorTimeMs = 50;
+        final long minTimeToResetRetryStateMs = 90000;
+
+        final ExponentialBackoffRetryStrategyConfig config = ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                .maxRetryCount(maxRetryCount)
+                .maxRetryWaitTimeMs(maxRetryWaitTimeMs)
+                .retryFactorTimeMs(retryFactorTimeMs)
+                .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
+                .noJitter()
+                .build();
+
+        final KvsRetryStrategy kvsRetryStrategy = KvsRetryStrategy.KvsRetryStrategyBuilder.with()
+                .exponentialBackoff()
+                .config(config)
+                .build();
+
+        final ClientInfo clientInfo = createClientInfoV2WithRetryStrategy(kvsRetryStrategy);
+        final DeviceInfo deviceInfo = createDeviceInfoV1(clientInfo);
+
+        createDescribeStreamErroredProducer(deviceInfo);
+
+        final String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String streamName = "DeviceInfoClientInfoVersionTest-" + methodName + "-" + System.currentTimeMillis();
+        streamExpectCreateFailure(streamName);
+
+        free();
+
+        // Since we're using max retries = 1, we should see this message. The describeStream state has a retryCount of 5.
+        final List<String> errorMessages = this.logCapture.getLogMessagesAtLevel(Level.ERROR);
+        final boolean containsMaxRetriesMessage = errorMessages.stream()
+                .anyMatch(message -> message.toLowerCase().contains(String.format("0x%08x", STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED)));
+        assertTrue("Did not find max retries in the logs", containsMaxRetriesMessage);
+
+        final boolean containsDescribeFailure = errorMessages.stream()
+                .anyMatch(message -> message.toLowerCase().contains(String.format("0x%08x", STATUS_DESCRIBE_STREAM_CALL_FAILED)));
+        assertTrue("Did not receive a describe stream failure in the logs", containsDescribeFailure);
+    }
+
+    /**
+     * Performs stream creation, putFrame, error verification, and resource cleanup.
+     *
+     * @param methodName Name of the caller method. A procedurally-generated stream name that includes the method name
+     *                   will be used.
+     */
+    private void streamNormally(final String methodName) {
+        try {
+            testStreaming(methodName, false);
+        } catch (final ProducerException e) {
+            log.error("Encountered an error while streaming!", e);
+            fail(e.getMessage());
+        }
+
+        // frameDropped_ is set to false initially. It can be set to true by droppedFrameReport callback in case there
+        // was a frame that was dropped during the test
+        assertFalse(this.frameDropped_);
+        // errorStatus_ is set to STATUS_SUCCESS initially. It can be set to a different statusCode by
+        // streamErrorReport callback in case an error is encountered during the test
+        assertEquals(STATUS_SUCCESS, this.errorStatus_);
+        // bufferingAckInSequence_ is true initially. It can be set to false by fragmentAckReceived callback in case the
+        // (current timestamp - previous timestamp of the ack) > fragment duration
+        assertTrue(this.bufferingAckInSequence_);
+    }
+
+    private void streamExpectCreateFailure(final String methodName) {
+        try {
+            testStreaming(methodName, true);
+            fail(methodName + " should have thrown an exception");
+        } catch (final ProducerException e) {
+            assertEquals("Should have failed to create stream with describeStream failure!",
+                    STATUS_DESCRIBE_STREAM_CALL_FAILED, e.getStatusCode());
+        }
+
+        // Since we're not streaming anything, we're not expecting any error codes
+        // errorStatus_ is set to STATUS_SUCCESS initially. It can be set to a different statusCode by
+        // streamErrorReport callback in case an error is encountered during the test
+        assertEquals(STATUS_SUCCESS, this.errorStatus_);
+    }
+
+    @SuppressWarnings({"UnnecessaryLocalVariable"})
+    private void testStreaming(final String methodName, final boolean skipPreparation) throws ProducerException {
+        final String streamName = "DeviceInfoClientInfoVersionTest-" + methodName + "-" + System.currentTimeMillis();
+        final StreamInfo.StreamingType streamingType = StreamInfo.StreamingType.STREAMING_TYPE_REALTIME;
+        final long maxLatency = TEN_SECONDS_HUNDREDS_OF_NANOS;
+        final long bufferDuration = TEN_SECONDS_HUNDREDS_OF_NANOS;
+
+        final KinesisVideoProducerStream stream = createTestStream(streamName, streamingType, maxLatency,
+                bufferDuration, StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_FLAG_NONE, skipPreparation);
+
+        final long now = System.currentTimeMillis();
+        final int fps = 10;
+        final int durationSec = 3;
+        final int keyFrameIntervalSec = 1;
+
+        // Stream durationSec seconds ago until now
+        for (int index = 0; index < durationSec * fps; index++) {
+            final int flags = index % (keyFrameIntervalSec * fps) == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+            final long frameDurationMs = 1000 / fps;
+            final long timestampMs = now - (durationSec * 1000) + index * frameDurationMs;
+            final long dtsPtsHundredsOfNanos = timestampMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+            final byte[] mockData = new byte[]{1, 2, 3, 4};
+            final KinesisVideoFrame testFrame = new KinesisVideoFrame(index, flags,
+                    dtsPtsHundredsOfNanos, dtsPtsHundredsOfNanos,
+                    1000 / fps * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, ByteBuffer.wrap(mockData));
+            try {
+                stream.putFrame(testFrame);
+
+                Thread.sleep(frameDurationMs);
+            } catch (final Exception e) {
+                log.error("Encountered an error while streaming!", e);
+                fail("Failed to put the frames into the stream! " + e.getMessage());
+            }
+        }
+        try {
+            Thread.sleep(WAIT_5_SECONDS_FOR_ACKS);
+        } catch (final InterruptedException e) {
+            log.error("Interrupted while waiting for the acks!", e);
+            fail();
+        }
+
+        freeTestStream(stream);
+
+        deleteStream(streamName);
+    }
+
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfigTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfigTest.java
@@ -1,0 +1,512 @@
+package com.amazonaws.kinesisvideo.producer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.JitterType.FIXED_JITTER;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.LIMIT_KVS_JITTER_FACTOR_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.MIN_KVS_JITTER_FACTOR_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.MIN_KVS_MAX_WAIT_TIME_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS;
+import static com.amazonaws.kinesisvideo.producer.ExponentialBackoffRetryStrategyConfig.MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for {@link ExponentialBackoffRetryStrategyConfig} class.
+ * Tests cover all builder methods, validation, and configuration scenarios.
+ */
+public class ExponentialBackoffRetryStrategyConfigTest {
+
+    private static final Logger log = LogManager.getLogger(ExponentialBackoffRetryStrategyConfigTest.class);
+
+    @Test
+    public void givenDefaultBuilder_whenBuildingConfig_thenAllFieldsUsePicDefaults() {
+        // Given/When
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .maxRetryWaitTimeMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .retryFactorTimeMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .minTimeToResetRetryStateMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .noJitter()
+                        .build();
+
+        // Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryCount());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryWaitTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getRetryFactorTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMinTimeToResetRetryStateMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.NO_JITTER, config.getJitterType());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenStaticDefaultsMethod_whenCalled_thenReturnsConfigWithDefaults() {
+        // Given/When
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.defaults();
+
+        // Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryCount());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryWaitTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getRetryFactorTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMinTimeToResetRetryStateMs());
+        assertNull(config.getJitterType());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenValidCustomValues_whenBuildingConfig_thenAllFieldsAreSetCorrectly() {
+        // Given
+        final long maxRetryCount = 5L;
+        final long maxRetryWaitTimeMs = 15000L;
+        final long retryFactorTimeMs = 500L;
+        final long minTimeToResetRetryStateMs = 100000L;
+        final long jitterFactor = 300L;
+
+        // When
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(maxRetryCount)
+                        .maxRetryWaitTimeMs(maxRetryWaitTimeMs)
+                        .retryFactorTimeMs(retryFactorTimeMs)
+                        .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
+                        .fixedJitter()
+                        .jitterFactor(jitterFactor)
+                        .build();
+
+        // Then
+        assertEquals(maxRetryCount, config.getMaxRetryCount());
+        assertEquals(maxRetryWaitTimeMs, config.getMaxRetryWaitTimeMs());
+        assertEquals(retryFactorTimeMs, config.getRetryFactorTimeMs());
+        assertEquals(minTimeToResetRetryStateMs, config.getMinTimeToResetRetryStateMs());
+        assertEquals(FIXED_JITTER, config.getJitterType());
+        assertEquals(jitterFactor, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenFullJitterType_whenBuildingConfig_thenJitterTypeIsSetCorrectly() {
+        // Given/When
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(1L)
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .fullJitter()
+                        .build();
+
+        // Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.FULL_JITTER, config.getJitterType());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenNoJitterType_whenBuildingConfig_thenJitterTypeIsSetCorrectly() {
+        // Given/When
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(1L)
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .noJitter()
+                        .build();
+
+        // Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.NO_JITTER, config.getJitterType());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenNegativeMaxRetryCount_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long negativeMaxRetryCount = -1L;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(negativeMaxRetryCount);
+
+            // Then
+            fail("Expected IllegalArgumentException for negative maxRetryCount");
+        } catch (final IllegalArgumentException e) {
+            assertEquals("maxRetryCount cannot be negative", e.getMessage());
+        }
+    }
+
+    @Test
+    public void givenMaxRetryWaitTimeBelowMinimum_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long belowMinimumWaitTime = MIN_KVS_MAX_WAIT_TIME_MILLISECONDS - 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(belowMinimumWaitTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for maxRetryWaitTimeMs below minimum");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenMaxRetryWaitTimeAboveLimit_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long aboveLimitWaitTime = LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS + 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(aboveLimitWaitTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for maxRetryWaitTimeMs above limit");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenRetryFactorTimeBelowMinimum_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long belowMinimumFactorTime = MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS - 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(belowMinimumFactorTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for retryFactorTimeMs below minimum");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenRetryFactorTimeAboveLimit_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long aboveLimitFactorTime = LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS + 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(aboveLimitFactorTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for retryFactorTimeMs above limit");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenMinTimeToResetRetryStateBelowMinimum_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long belowMinimumResetTime = MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS - 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                    .minTimeToResetRetryStateMs(belowMinimumResetTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for minTimeToResetRetryStateMs below minimum");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenMinTimeToResetRetryStateAboveLimit_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long aboveLimitResetTime = LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS + 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                    .minTimeToResetRetryStateMs(aboveLimitResetTime);
+
+            // Then
+            fail("Expected IllegalArgumentException for minTimeToResetRetryStateMs above limit");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenJitterFactorBelowMinimum_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long belowMinimumJitterFactor = MIN_KVS_JITTER_FACTOR_MILLISECONDS - 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                    .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                    .fixedJitter()
+                    .jitterFactor(belowMinimumJitterFactor);
+
+            // Then
+            fail("Expected IllegalArgumentException for jitterFactor below minimum");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenJitterFactorAboveLimit_whenBuilding_thenThrowsIllegalArgumentException() {
+        // Given
+        final long aboveLimitJitterFactor = LIMIT_KVS_JITTER_FACTOR_MILLISECONDS + 1;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                    .maxRetryCount(1L)
+                    .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                    .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                    .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                    .fixedJitter()
+                    .jitterFactor(aboveLimitJitterFactor);
+
+            // Then
+            fail("Expected IllegalArgumentException for jitterFactor above limit");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenBoundaryValues_whenBuilding_thenConfigIsCreatedSuccessfully() {
+        // Given - Test minimum boundary values
+        final ExponentialBackoffRetryStrategyConfig minConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(0L) // Minimum allowed
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .fixedJitter()
+                        .jitterFactor(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .build();
+
+        // When - Test maximum boundary values
+        final ExponentialBackoffRetryStrategyConfig maxConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(Long.MAX_VALUE) // Any positive value allowed
+                        .maxRetryWaitTimeMs(LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .fixedJitter()
+                        .jitterFactor(LIMIT_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .build();
+
+        // Then
+        assertEquals(0L, minConfig.getMaxRetryCount());
+        assertEquals(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS, minConfig.getMaxRetryWaitTimeMs());
+        assertEquals(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS, minConfig.getRetryFactorTimeMs());
+        assertEquals(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS, minConfig.getMinTimeToResetRetryStateMs());
+        assertEquals(MIN_KVS_JITTER_FACTOR_MILLISECONDS, minConfig.getJitterFactor());
+
+        assertEquals(Long.MAX_VALUE, maxConfig.getMaxRetryCount());
+        assertEquals(LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS, maxConfig.getMaxRetryWaitTimeMs());
+        assertEquals(LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS, maxConfig.getRetryFactorTimeMs());
+        assertEquals(LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS, maxConfig.getMinTimeToResetRetryStateMs());
+        assertEquals(LIMIT_KVS_JITTER_FACTOR_MILLISECONDS, maxConfig.getJitterFactor());
+    }
+
+    @Test
+    public void givenUsePicDefaultValues_whenBuilding_thenValidationIsSkipped() {
+        // Given/When - USE_PIC_DEFAULT should bypass validation
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .maxRetryWaitTimeMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .retryFactorTimeMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .minTimeToResetRetryStateMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .fixedJitter()
+                        .jitterFactor(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .build();
+
+        // Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryCount());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMaxRetryWaitTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getRetryFactorTimeMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getMinTimeToResetRetryStateMs());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT, config.getJitterFactor());
+    }
+
+    @Test
+    public void givenNullBuilder_whenCreatingConfig_thenThrowsIllegalArgumentException() {
+        try {
+            // Given/When
+            new ExponentialBackoffRetryStrategyConfig(null);
+
+            // Then
+            fail("Expected IllegalArgumentException for null builder");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenJitterTypeValues_whenGettingJitterTypeValue_thenReturnsCorrectIntegerValues() {
+        // Given
+        final ExponentialBackoffRetryStrategyConfig noJitterConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(1L)
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .noJitter()
+                        .build();
+
+        final ExponentialBackoffRetryStrategyConfig fullJitterConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(1L)
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .fullJitter()
+                        .build();
+
+        final ExponentialBackoffRetryStrategyConfig fixedJitterConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(1L)
+                        .maxRetryWaitTimeMs(MIN_KVS_MAX_WAIT_TIME_MILLISECONDS)
+                        .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
+                        .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
+                        .fixedJitter()
+                        .jitterFactor(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .build();
+
+        final ExponentialBackoffRetryStrategyConfig defaultsConfig =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.defaults();
+
+        // When/Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.NO_JITTER.getValue(),
+                noJitterConfig.getJitterTypeValue());
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.FULL_JITTER.getValue(),
+                fullJitterConfig.getJitterTypeValue());
+        assertEquals(FIXED_JITTER.getValue(),
+                fixedJitterConfig.getJitterTypeValue());
+        assertEquals((int) ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT,
+                defaultsConfig.getJitterTypeValue());
+    }
+
+    @Test
+    public void givenJitterTypeEnumValues_whenCallingFromValue_thenReturnsCorrectEnumValues() {
+        // Given/When/Then
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.FULL_JITTER,
+                ExponentialBackoffRetryStrategyConfig.JitterType.fromValue(0x01));
+        assertEquals(FIXED_JITTER,
+                ExponentialBackoffRetryStrategyConfig.JitterType.fromValue(0x02));
+        assertEquals(ExponentialBackoffRetryStrategyConfig.JitterType.NO_JITTER,
+                ExponentialBackoffRetryStrategyConfig.JitterType.fromValue(0x03));
+    }
+
+    @Test
+    public void givenInvalidJitterTypeValue_whenCallingFromValue_thenThrowsIllegalArgumentException() {
+        // Given
+        final int invalidValue = 999;
+
+        try {
+            // When
+            ExponentialBackoffRetryStrategyConfig.JitterType.fromValue(invalidValue);
+
+            // Then
+            fail("Expected IllegalArgumentException for invalid jitter type value");
+        } catch (final IllegalArgumentException e) {
+            // Happy path
+            log.trace("Received expected exception", e);
+        }
+    }
+
+    @Test
+    public void givenConfigWithAllValues_whenCallingToString_thenReturnsFormattedString() {
+        // Given
+        final long maxRetryCount = 9L;
+        final long maxRetryWaitTimeMs = 15000L;
+        final long retryFactorTimeMs = 501L;
+        final long minTimeToResetRetryStateMs = 100000L;
+        final long jitterFactor = 300L;
+
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.with()
+                        .maxRetryCount(maxRetryCount)
+                        .maxRetryWaitTimeMs(maxRetryWaitTimeMs)
+                        .retryFactorTimeMs(retryFactorTimeMs)
+                        .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
+                        .fixedJitter()
+                        .jitterFactor(jitterFactor)
+                        .build();
+
+        // When
+        final String result = config.toString();
+
+        // Then
+        assertTrue("It should contain the class name ExponentialBackoffRetryStrategyConfig", result.contains("ExponentialBackoffRetryStrategyConfig"));
+        assertTrue("It should contain maxRetryCount", result.contains("maxRetryCount"));
+        assertTrue("It should contain maxRetryWaitTime", result.contains("maxRetryWaitTime"));
+        assertTrue("It should contain retryFactorTime", result.contains("retryFactorTime"));
+        assertTrue("It should contain minTimeToResetRetryStateMs", result.contains("minTimeToResetRetryStateMs"));
+        assertTrue("It should contain jitterType", result.contains("jitterType"));
+        assertTrue("It should contain jitterFactor", result.contains("jitterFactor"));
+
+        assertTrue("It should contain maxRetryCount value", result.contains(Long.toString(maxRetryCount)));
+        assertTrue("It should contain maxRetryWaitTime value", result.contains(Long.toString(maxRetryWaitTimeMs)));
+        assertTrue("It should contain retryFactorTime value", result.contains(Long.toString(retryFactorTimeMs)));
+        assertTrue("It should contain minTimeToResetRetryStateMs value", result.contains(Long.toString(minTimeToResetRetryStateMs)));
+        assertTrue("It should contain jitterType value", result.contains(FIXED_JITTER.toString()));
+        assertTrue("It should contain jitterFactor value", result.contains(Long.toString(jitterFactor)));
+    }
+
+    @Test
+    public void givenConfigWithPicDefaults_whenCallingToString_thenShowsPicDefaultLabels() {
+        // Given
+        final int NUM_FIELDS = 6;
+        final ExponentialBackoffRetryStrategyConfig config =
+                ExponentialBackoffRetryStrategyConfig.ExponentialBackoffRetryStrategyConfigBuilder.defaults();
+
+        // When
+        final String result = config.toString();
+
+        // Then
+        final int occurrancesOfDefaultString = StringUtils.countMatches(result, "PIC_DEFAULT");
+        assertEquals("It should say PIC_DEFAULT " + NUM_FIELDS + " times, but only found it " +
+                occurrancesOfDefaultString + " times in " + result, NUM_FIELDS, occurrancesOfDefaultString);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfigTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/ExponentialBackoffRetryStrategyConfigTest.java
@@ -80,7 +80,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(retryFactorTimeMs)
                         .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
                         .fixedJitter()
-                        .jitterFactor(jitterFactor)
+                        .jitterFactorMillis(jitterFactor)
                         .build();
 
         // Then
@@ -276,7 +276,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                     .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
                     .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
                     .fixedJitter()
-                    .jitterFactor(belowMinimumJitterFactor);
+                    .jitterFactorMillis(belowMinimumJitterFactor);
 
             // Then
             fail("Expected IllegalArgumentException for jitterFactor below minimum");
@@ -299,7 +299,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                     .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
                     .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
                     .fixedJitter()
-                    .jitterFactor(aboveLimitJitterFactor);
+                    .jitterFactorMillis(aboveLimitJitterFactor);
 
             // Then
             fail("Expected IllegalArgumentException for jitterFactor above limit");
@@ -319,7 +319,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
                         .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
                         .fixedJitter()
-                        .jitterFactor(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .jitterFactorMillis(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
                         .build();
 
         // When - Test maximum boundary values
@@ -330,7 +330,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
                         .minTimeToResetRetryStateMs(LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
                         .fixedJitter()
-                        .jitterFactor(LIMIT_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .jitterFactorMillis(LIMIT_KVS_JITTER_FACTOR_MILLISECONDS)
                         .build();
 
         // Then
@@ -357,7 +357,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
                         .minTimeToResetRetryStateMs(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
                         .fixedJitter()
-                        .jitterFactor(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
+                        .jitterFactorMillis(ExponentialBackoffRetryStrategyConfig.USE_PIC_DEFAULT)
                         .build();
 
         // Then
@@ -410,7 +410,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS)
                         .minTimeToResetRetryStateMs(MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS)
                         .fixedJitter()
-                        .jitterFactor(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
+                        .jitterFactorMillis(MIN_KVS_JITTER_FACTOR_MILLISECONDS)
                         .build();
 
         final ExponentialBackoffRetryStrategyConfig defaultsConfig =
@@ -471,7 +471,7 @@ public class ExponentialBackoffRetryStrategyConfigTest {
                         .retryFactorTimeMs(retryFactorTimeMs)
                         .minTimeToResetRetryStateMs(minTimeToResetRetryStateMs)
                         .fixedJitter()
-                        .jitterFactor(jitterFactor)
+                        .jitterFactorMillis(jitterFactor)
                         .build();
 
         // When

--- a/src/test/java/com/amazonaws/kinesisvideo/util/LogCaptureRule.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/util/LogCaptureRule.java
@@ -94,6 +94,9 @@ public class LogCaptureRule extends ExternalResource {
      * Sets up log capture for testing
      */
     private void setupLogCapture() {
+        // Clean up any existing appender first
+        cleanupLogCapture();
+        
         this.testLogAppender = new TestLogAppender();
         this.testLogAppender.start();
 

--- a/src/test/java/com/amazonaws/kinesisvideo/util/LogCaptureRule.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/util/LogCaptureRule.java
@@ -1,0 +1,153 @@
+package com.amazonaws.kinesisvideo.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.message.Message;
+import org.junit.rules.ExternalResource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * JUnit rule for capturing log messages during test execution.
+ * This rule automatically sets up and tears down log capture, making it easy to
+ * verify that expected log messages are generated during tests.
+ *
+ * <p>Usage example:
+ * <pre>
+ * public class SomeTest {
+ *     &#64;Rule
+ *     public LogCaptureRule logCapture = new LogCaptureRule();
+ *
+ *     &#64;Test
+ *     public void testSomething() {
+ *         // ... test code that generates logs ...
+ *
+ *         List&lt;String&gt; errorMessages = logCapture.getLogMessagesAtLevel(Level.ERROR);
+ *         assertTrue("Expected error message not found",
+ *                   errorMessages.stream().anyMatch(msg -> msg.contains("expected error")));
+ *     }
+ * }
+ * </pre>
+ */
+public class LogCaptureRule extends ExternalResource {
+
+    private TestLogAppender testLogAppender;
+
+    /**
+     * Custom Log4j2 appender to capture log messages for testing
+     */
+    private static class TestLogAppender extends AbstractAppender {
+        private final List<LogEvent> logEvents = new ArrayList<>();
+
+        protected TestLogAppender() {
+            super("TestLogAppender", null, PatternLayout.createDefaultLayout(), true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            this.logEvents.add(event.toImmutable());
+        }
+
+        public List<LogEvent> getLogEvents() {
+            return new ArrayList<>(this.logEvents);
+        }
+
+        public void clearLogs() {
+            this.logEvents.clear();
+        }
+
+        public List<String> getLogMessages() {
+            return this.logEvents.stream()
+                    .map(LogEvent::getMessage)
+                    .map(Message::getFormattedMessage)
+                    .collect(Collectors.toList());
+        }
+
+        public List<String> getLogMessagesAtLevel(final Level level) {
+            return this.logEvents.stream()
+                    .filter(event -> event.getLevel().equals(level))
+                    .map(LogEvent::getMessage)
+                    .map(Message::getFormattedMessage)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        setupLogCapture();
+    }
+
+    @Override
+    protected void after() {
+        cleanupLogCapture();
+    }
+
+    /**
+     * Sets up log capture for testing
+     */
+    private void setupLogCapture() {
+        this.testLogAppender = new TestLogAppender();
+        this.testLogAppender.start();
+
+        // Get the root logger and add our test appender
+        final Logger rootLogger = (Logger) LogManager.getRootLogger();
+        rootLogger.addAppender(this.testLogAppender);
+    }
+
+    /**
+     * Cleans up log capture after testing
+     */
+    private void cleanupLogCapture() {
+        if (this.testLogAppender != null) {
+            final Logger rootLogger = (Logger) LogManager.getRootLogger();
+            rootLogger.removeAppender(this.testLogAppender);
+            this.testLogAppender.stop();
+            this.testLogAppender = null;
+        }
+    }
+
+    /**
+     * Gets all captured log messages as strings
+     *
+     * @return List of log messages as strings
+     */
+    public List<String> getLogMessages() {
+        return this.testLogAppender != null ? this.testLogAppender.getLogMessages() : Collections.emptyList();
+    }
+
+    /**
+     * Gets the captured log messages at a specific level
+     *
+     * @param level The log level to filter by
+     * @return List of log messages at the specified level
+     */
+    public List<String> getLogMessagesAtLevel(final Level level) {
+        return this.testLogAppender != null ? this.testLogAppender.getLogMessagesAtLevel(level) : Collections.emptyList();
+    }
+
+    /**
+     * Clears all captured log messages
+     */
+    public void clearLogs() {
+        if (this.testLogAppender != null) {
+            this.testLogAppender.clearLogs();
+        }
+    }
+
+    /**
+     * Gets all captured log events (for advanced use cases)
+     *
+     * @return List of LogEvent objects
+     */
+    public List<LogEvent> getLogEvents() {
+        return this.testLogAppender != null ? this.testLogAppender.getLogEvents() : Collections.emptyList();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Deprecated the constructors for ClientInfo and DeviceInfo and replaced them with new factory methods
- Struct version handling in the C++ layer
- Add the RetryStrategy which was missing as the V2 ClientInfo parameter. (Improvement to #211)

*Why was it changed?*
- For background, whenever the PIC layer adds a new constructor parameter for the client, it requires the Java/C++ layer models to also match. The C++ layer always uses the latest version in the PIC, causing undefined behavior when the JNI version does not match the PIC version of the struct. With these changes, only the relevant variables will be read and we will not read any uninitialized (garbage) memory.

*How was it changed?*
- Instead of creating the latest struct in the C++ layer, we will only create the struct version specified by the Java side. The C++ layer will only set the relevant fields.
- The Java side received new factory methods that create the correct version of the struct. This fixes an issue where some values in the Java side were not being applied. This is because the supplied struct version was too low, meaning that PIC thinks the values for the higher versions contain garbage, and thus fallback to the default, even though they are not actually garbage. This change prevents such misconfigurations from occurring any more.

*What testing was done for the changes?*
- Created new tests to validate the input parameters and new factory methods
- Created a new LogCaptureRule to capture the logs from the PIC layer to make sure the retry strategy (retry backoff calculation) is being applied correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
