### PR TITLE
Add initial tests for multi-client scenarios

### DIFF
--- a/src/test/java/com/amazonaws/kinesisvideo/common/MultiClientTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/MultiClientTest.java
@@ -1,0 +1,497 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.kinesisvideo.auth.DefaultAuthCallbacks;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
+import com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducer;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.internal.producer.ServiceCallbacks;
+import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.java.auth.JavaCredentialsFactory;
+import com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient;
+import com.amazonaws.kinesisvideo.producer.AuthCallbacks;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFragmentAck;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageCallbacks;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamCallbacks;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.kinesisvideo.producer.Time;
+import com.amazonaws.kinesisvideo.storage.DefaultStorageCallbacks;
+import com.amazonaws.kinesisvideo.streaming.DefaultStreamCallbacks;
+import com.amazonaws.kinesisvideo.util.StreamInfoConstants;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.CreateStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.PRODUCER_NATIVE_LIBRARY_NAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Multi-Client Test - Validates per-client JVM context refactoring
+ * <p>
+ * This test ensures that multiple KinesisVideoClient instances can operate
+ * independently without interfering with each other's callbacks or logging.
+ */
+public class MultiClientTest extends ProducerTestBase {
+    private static final Logger log = LogManager.getLogger(MultiClientTest.class);
+    private static final int NUM_CLIENTS = 3;
+    private static final int FRAMES_PER_CLIENT = 500;
+    private static final int FPS = 50;
+
+    private static final long FRAME_DURATION_MS = 1000 / FPS;
+    private static final int KEYFRAME_INTERVAL = FPS; // GOP = 1 second
+
+    private ExecutorService testExecutor;
+
+    private final List<TestStreamContext> streamContexts = new ArrayList<>();
+
+    private final int GRACE_PERIOD_SECS = 10;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(FRAMES_PER_CLIENT / FPS + this.GRACE_PERIOD_SECS);
+
+    private static class TestStreamContext {
+        @Nullable
+        NativeKinesisVideoClient client = null;
+        @Nullable
+        KinesisVideoProducer producer = null;
+        @Nullable
+        KinesisVideoProducerStream stream = null;
+        @Nullable
+        List<KinesisVideoFragmentAck> acksReceived = null;
+        @Nullable
+        ScheduledExecutorService scheduledExecutorService = null;
+        @Nullable
+        String streamName = null;
+        @Nonnull
+        AtomicBoolean describeStreamCalled = new AtomicBoolean(false);
+        @Nonnull
+        AtomicBoolean putMediaCalled = new AtomicBoolean(false);
+        @Nonnull
+        AtomicBoolean streamReadyCalled = new AtomicBoolean(false);
+        @Nonnull
+        AtomicBoolean streamClosedCalled = new AtomicBoolean(false);
+    }
+
+    private KinesisVideoClientConfiguration clientConfiguration;
+
+    @Before
+    public void setUp() {
+        try {
+            System.loadLibrary(PRODUCER_NATIVE_LIBRARY_NAME);
+        } catch (final UnsatisfiedLinkError e) {
+            fail("JNI library not found.");
+        }
+
+        this.testExecutor = Executors.newFixedThreadPool(NUM_CLIENTS * 2);
+
+        assumeTrue(DefaultAWSCredentialsProviderChain.getInstance().getCredentials() != null);
+
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        final AmazonKinesisVideo awsSdkKinesisVideoClient = AmazonKinesisVideoClientBuilder.standard().build();
+        boolean success = true;
+
+        this.clientConfiguration = KinesisVideoClientConfiguration.builder()
+                .withCredentialsProvider(JavaCredentialsFactory.createKinesisVideoCredentialsProvider(DefaultAWSCredentialsProviderChain.getInstance()))
+                .build();
+
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            final String streamName = String.join("-", prefix, "test-multi-client-stream",
+                    Integer.toString(i), Long.toString(System.currentTimeMillis()), UUID.randomUUID().toString());
+            try {
+                log.info("Creating stream {}", streamName);
+                final CreateStreamRequest createStreamRequest = new CreateStreamRequest()
+                        .withStreamName(streamName)
+                        .withDataRetentionInHours(2);
+                awsSdkKinesisVideoClient.createStream(createStreamRequest);
+                final TestStreamContext testStreamContext = new TestStreamContext();
+                testStreamContext.streamName = streamName;
+                this.streamContexts.add(testStreamContext);
+            } catch (final Throwable t) {
+                log.error("Encountered an error creating stream: {}!", streamName, t);
+                success = false;
+            }
+        }
+
+        assertTrue("There was an issue creating streams, check the logs above!", success);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Clean up streams
+        boolean success = true;
+        for (final TestStreamContext testStreamContext : this.streamContexts) {
+            final NativeKinesisVideoClient client = testStreamContext.client;
+            final KinesisVideoProducer producer = testStreamContext.producer;
+            final KinesisVideoProducerStream stream = testStreamContext.stream;
+            final ScheduledExecutorService scheduledExecutorService = testStreamContext.scheduledExecutorService;
+
+            if (stream != null) {
+                try {
+                    stream.stopStreamSync();
+                } catch (final Exception e) {
+                    log.warn("Error stopping stream: " + e.getMessage());
+                    success = false;
+                }
+            }
+
+            if (producer != null) {
+                try {
+                    producer.free();
+                } catch (final Exception e) {
+                    log.warn("Error freeing producer", e);
+                    success = false;
+                }
+            }
+
+            if (client != null) {
+                try {
+                    client.free();
+                } catch (final Exception e) {
+                    log.warn("Error freeing client: " + e.getMessage());
+                    success = false;
+                }
+            }
+
+            if (scheduledExecutorService != null) {
+                scheduledExecutorService.shutdownNow();
+            }
+        }
+
+        if (this.testExecutor != null) {
+            this.testExecutor.shutdown();
+            assumeTrue("Timed out while shutting down", this.testExecutor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+
+        // Clean up streams from AWS
+        deleteStreams();
+
+        assertTrue("There was an issue in the cleanup, check the logs above.", success);
+    }
+
+    @Test
+    @SuppressWarnings("ExtractMethodRecommender")
+    public void givenMultipleStreamContexts_whenCreatingClientsAndProducers_thenAllInstancesAreCreatedSuccessfully() throws Exception {
+        // Create multiple clients
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            final TestStreamContext testStreamContext = this.streamContexts.get(i);
+            assumeNotNull(testStreamContext);
+            testStreamContext.scheduledExecutorService = Executors.newScheduledThreadPool(2);
+            final DeviceInfo deviceInfo = createTestDeviceInfo("test-device-" + i);
+
+            final AuthCallbacks authCallbacks = new DefaultAuthCallbacks(this.clientConfiguration.getCredentialsProvider(),
+                    testStreamContext.scheduledExecutorService, LogManager.getLogger(DefaultAuthCallbacks.class));
+
+            final StorageCallbacks storageCallbacks = new DefaultStorageCallbacks();
+            final ServiceCallbacks serviceCallbacks = new DefaultServiceCallbacksImpl(log, testStreamContext.scheduledExecutorService,
+                    this.clientConfiguration, new JavaKinesisVideoServiceClient());
+            final StreamCallbacks streamCallbacks = new DefaultStreamCallbacks();
+
+            final NativeKinesisVideoClient client = new NativeKinesisVideoClient(log, authCallbacks, storageCallbacks,
+                    serviceCallbacks, streamCallbacks);
+
+            client.initialize(deviceInfo);
+            testStreamContext.client = client;
+
+            assertTrue("Producer " + i + " should be initialized", client.isInitialized());
+        }
+
+        // Cleanup will free the clients and producers to verify that we can free them in the order they were created
+    }
+
+    @Test
+    public void givenMultipleStreamContexts_whenCreatingClientsAndProducersInReverseOrder_thenAllInstancesAreCreatedSuccessfully() throws Exception {
+        givenMultipleStreamContexts_whenCreatingClientsAndProducers_thenAllInstancesAreCreatedSuccessfully();
+
+        // Verify that we can delete clients in a different order
+        Collections.reverse(this.streamContexts);
+    }
+
+    /**
+     * Test 2: Multiple clients can stream simultaneously without interference
+     */
+    @Test
+    public void givenMultipleClientsAndStreams_whenStreamingConcurrently_thenAllClientsReceiveTheirOwnCallbacks() throws Exception {
+        log.info("Testing concurrent streaming with multiple clients");
+
+        // Create clients and streams
+        createMultipleClientsAndStreams();
+
+        final List<Future<Void>> streamingTasks = new ArrayList<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+
+        for (int clientIndex = 0; clientIndex < NUM_CLIENTS; clientIndex++) {
+            final int finalClientIndex = clientIndex;
+            final TestStreamContext testStreamContext = this.streamContexts.get(clientIndex);
+            assumeNotNull(testStreamContext);
+            assumeNotNull(testStreamContext.stream);
+
+            final Future<Void> task = this.testExecutor.submit(() -> {
+                try {
+                    // Wait for the start signal
+                    startLatch.await();
+
+                    streamFrames(testStreamContext);
+
+                    testStreamContext.stream.stopStreamSync();
+                } catch (final Exception e) {
+                    log.error("Error streaming for client {}", finalClientIndex, e);
+                    throw new RuntimeException(e);
+                }
+                return null;
+            });
+            streamingTasks.add(task);
+        }
+
+        // Kickoff all the streams at the same time
+        startLatch.countDown();
+
+        // Wait for all streaming to complete
+        for (final Future<Void> task : streamingTasks) {
+            task.get(FRAMES_PER_CLIENT / FPS + this.GRACE_PERIOD_SECS, TimeUnit.SECONDS);
+        }
+
+        // Verify each client received its own callbacks
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            final TestStreamContext testStreamContext = this.streamContexts.get(i);
+            assumeNotNull(testStreamContext);
+            assumeNotNull(testStreamContext.acksReceived);
+
+            assertFalse("Client " + i + " should have received ACKs!", testStreamContext.acksReceived.isEmpty());
+
+            assertTrue("StreamReady callback was not invoked for client/stream " + i + ", streamName=" + testStreamContext.streamName,
+                    testStreamContext.streamReadyCalled.get());
+            assertTrue("StreamClosed callback was not invoked for client/stream " + i + ", streamName=" + testStreamContext.streamName,
+                    testStreamContext.streamClosedCalled.get());
+
+            assertTrue("DescribeStream callback was not invoked for client/stream " + i + ", streamName=" + testStreamContext.streamName,
+                    testStreamContext.describeStreamCalled.get());
+            assertTrue("PutMedia callback was not invoked for client/stream " + i + ", streamName=" + testStreamContext.streamName,
+                    testStreamContext.putMediaCalled.get());
+        }
+    }
+
+    // Creates clients and streams in order: (Client, Stream), (Client, Stream), ...
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ExtractMethodRecommender"})
+    private void createMultipleClientsAndStreams() throws Exception {
+        for (int i = 0; i < NUM_CLIENTS; i++) {
+            final TestStreamContext testStreamContext = this.streamContexts.get(i);
+            assumeNotNull(testStreamContext);
+
+            final String streamName = testStreamContext.streamName;
+            final DeviceInfo deviceInfo = createTestDeviceInfo("test-device-" + i);
+            testStreamContext.scheduledExecutorService = Executors.newScheduledThreadPool(2);
+
+            final AuthCallbacks authCallbacks = new DefaultAuthCallbacks(this.clientConfiguration.getCredentialsProvider(),
+                    testStreamContext.scheduledExecutorService, LogManager.getLogger(DefaultAuthCallbacks.class));
+
+            final StorageCallbacks storageCallbacks = new DefaultStorageCallbacks();
+            final ServiceCallbacks serviceCallbacks = new DefaultServiceCallbacksImpl(log,
+                    testStreamContext.scheduledExecutorService, this.clientConfiguration, new JavaKinesisVideoServiceClient()) {
+                @Override
+                public void describeStream(@Nonnull final String streamName, final long callAfter, final long timeout, @Nullable final byte[] authData, final int authType, final long streamHandle, final KinesisVideoProducerStream stream) throws ProducerException {
+                    testStreamContext.describeStreamCalled.set(true);
+                    super.describeStream(streamName, callAfter, timeout, authData, authType, streamHandle, stream);
+                }
+
+                @Override
+                public void putStream(@Nonnull final String streamName, @Nonnull final String containerType, final long streamStartTime, final boolean absoluteFragmentTimes, final boolean ackRequired, @Nonnull final String dataEndpoint, final long callAfter, final long timeout, @Nullable final byte[] authData, final int authType, final KinesisVideoProducerStream kinesisVideoProducerStream) throws ProducerException {
+                    testStreamContext.putMediaCalled.set(true);
+                    super.putStream(streamName, containerType, streamStartTime, absoluteFragmentTimes, ackRequired, dataEndpoint, callAfter, timeout, authData, authType, kinesisVideoProducerStream);
+                }
+            };
+            final StreamCallbacks streamCallbacks = new DefaultStreamCallbacks();
+
+            final NativeKinesisVideoClient client = new NativeKinesisVideoClient(log, authCallbacks, storageCallbacks,
+                    serviceCallbacks, streamCallbacks);
+            testStreamContext.client = client;
+
+            final KinesisVideoProducer producer = client.initializeNewKinesisVideoProducer(deviceInfo);
+            testStreamContext.producer = producer;
+
+            final List<KinesisVideoFragmentAck> fragmentAcksReceived = new ArrayList<>();
+            testStreamContext.acksReceived = fragmentAcksReceived;
+
+            final StreamInfo streamInfo = createStreamInfo(streamName);
+            final KinesisVideoProducerStream stream = producer.createStreamSync(streamInfo, new DefaultStreamCallbacks() {
+                @Override
+                public void fragmentAckReceived(final long uploadHandle, @Nonnull final KinesisVideoFragmentAck fragmentAck)
+                        throws ProducerException {
+                    super.fragmentAckReceived(uploadHandle, fragmentAck);
+                    log.info("Received {} for stream: {}", fragmentAck, streamName);
+                    fragmentAcksReceived.add(fragmentAck);
+                }
+
+                @Override
+                public void streamReady() throws ProducerException {
+                    testStreamContext.streamReadyCalled.set(true);
+                    super.streamReady();
+                }
+
+                @Override
+                public void streamClosed(final long uploadHandle) throws ProducerException {
+                    testStreamContext.streamClosedCalled.set(true);
+                    super.streamClosed(uploadHandle);
+                }
+            });
+            testStreamContext.stream = stream;
+        }
+    }
+
+    private void streamFrames(@Nonnull final TestStreamContext testStreamContext)
+            throws Exception {
+        assumeNotNull(testStreamContext);
+
+        final KinesisVideoProducerStream stream = testStreamContext.stream;
+        assumeNotNull(stream);
+
+        final String streamName = testStreamContext.streamName;
+        assumeNotNull(streamName);
+
+        final long startTimestampMs = System.currentTimeMillis();
+        for (int frameIndex = 0; frameIndex < FRAMES_PER_CLIENT; frameIndex++) {
+            final long currentTimestampMs = startTimestampMs + (frameIndex * FRAME_DURATION_MS);
+            final long timestampHundredsOfNanos = currentTimestampMs * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+            final String frameData = streamName + "-Frame-" + frameIndex + "-Data";
+            final ByteBuffer frameBuffer = ByteBuffer.wrap(frameData.getBytes());
+
+            final int frameFlags = frameIndex % KEYFRAME_INTERVAL == 0 ?
+                    FRAME_FLAG_KEY_FRAME :
+                    FRAME_FLAG_NONE;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    frameFlags,
+                    timestampHundredsOfNanos,
+                    timestampHundredsOfNanos,
+                    FRAME_DURATION_MS * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    frameBuffer
+            );
+
+            stream.putFrame(frame);
+            Thread.sleep(FRAME_DURATION_MS);
+        }
+    }
+
+    @Nonnull
+    @SuppressWarnings("ConstantConditions")
+    private DeviceInfo createTestDeviceInfo(@Nonnull final String deviceName) {
+        assumeNotNull("Device name cannot be null", deviceName);
+
+        final int storageInfoVersion = 0;
+        final StorageInfo.DeviceStorageType storageType = StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM;
+        final long storageSizeBytes = 1024 * 1024 * 10; // 10 MB
+        final int spillRatio = 90;
+        final String rootDirectory = "/tmp";
+        final StorageInfo storageInfo = new StorageInfo(storageInfoVersion,
+                storageType,
+                storageSizeBytes,
+                spillRatio,
+                rootDirectory);
+
+        final int deviceInfoVersion = 0;
+        final Tag[] tags = null;
+        final int numStreams = 1;
+        return new DeviceInfo(deviceInfoVersion,
+                deviceName,
+                storageInfo,
+                numStreams,
+                tags);
+    }
+
+    private StreamInfo createStreamInfo(final String streamName) {
+        return new StreamInfo(
+                StreamInfo.STREAM_INFO_CURRENT_VERSION,
+                streamName,
+                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME,
+                "video/h264",
+                StreamInfoConstants.NO_KMS_KEY_ID,
+                StreamInfoConstants.RETENTION_ONE_HOUR,
+                StreamInfoConstants.NOT_ADAPTIVE,
+                StreamInfoConstants.MAX_LATENCY_ZERO,
+                StreamInfoConstants.DEFAULT_GOP_DURATION,
+                StreamInfoConstants.KEYFRAME_FRAGMENTATION,
+                StreamInfoConstants.USE_FRAME_TIMECODES,
+                StreamInfoConstants.RELATIVE_TIMECODES,
+                StreamInfoConstants.REQUEST_FRAGMENT_ACKS,
+                StreamInfoConstants.RECOVER_ON_FAILURE,
+                "V_MPEG4/ISO/AVC",
+                "test-track",
+                StreamInfoConstants.DEFAULT_BITRATE,
+                MultiClientTest.FPS,
+                StreamInfoConstants.DEFAULT_BUFFER_DURATION,
+                StreamInfoConstants.DEFAULT_REPLAY_DURATION,
+                StreamInfoConstants.DEFAULT_STALENESS_DURATION,
+                StreamInfoConstants.DEFAULT_TIMESCALE,
+                StreamInfoConstants.RECALCULATE_METRICS,
+                null,
+                new Tag[]{
+                        new Tag("device", "Test Device"),
+                        new Tag("stream", "Test Stream")},
+                StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_FLAG_NONE,
+                this.allowStreamCreation
+        );
+    }
+
+    private void deleteStreams() {
+        final AmazonKinesisVideo awsSdkKinesisVideoClient = AmazonKinesisVideoClientBuilder.standard().build();
+        boolean success = true;
+        for (final TestStreamContext testStreamContext : this.streamContexts) {
+            final String streamName = testStreamContext.streamName;
+            if (streamName == null) {
+                continue;
+            }
+
+            try {
+                log.info("Deleting stream {}", streamName);
+                final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest().withStreamName(streamName);
+                final DescribeStreamResult describeStreamResult = awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+
+                final DeleteStreamRequest deleteStreamRequest = new DeleteStreamRequest()
+                        .withStreamARN(describeStreamResult.getStreamInfo().getStreamARN())
+                        .withCurrentVersion(describeStreamResult.getStreamInfo().getVersion());
+                awsSdkKinesisVideoClient.deleteStream(deleteStreamRequest);
+            } catch (final Throwable t) {
+                log.error("Encountered an error deleting healthy stream: {}!", streamName, t);
+                success = false;
+            }
+        }
+        assertTrue("Encountered an issue cleaning up the streams! Check the logs above", success);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/MultiJniIntegTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/MultiJniIntegTest.java
@@ -1,0 +1,436 @@
+package com.amazonaws.kinesisvideo.producer;
+
+import com.amazonaws.kinesisvideo.auth.DefaultAuthCallbacks;
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentials;
+import com.amazonaws.kinesisvideo.auth.KinesisVideoCredentialsProvider;
+import com.amazonaws.kinesisvideo.auth.StaticCredentialsProvider;
+import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfiguration;
+import com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni;
+import com.amazonaws.kinesisvideo.internal.service.DefaultServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.java.service.JavaKinesisVideoServiceClient;
+import com.amazonaws.kinesisvideo.storage.DefaultStorageCallbacks;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.PRODUCER_NATIVE_LIBRARY_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Integration tests for multi-instance JNI producer functionality.
+ *
+ * <p>This test suite validates that the native Kinesis Video Producer JNI layer can handle
+ * multiple concurrent instances without interference, memory leaks, or resource conflicts.
+ *
+ * <p>Scenarios tested:
+ * <ul>
+ *   <li>Sequential creation of multiple JNI instances</li>
+ *   <li>Concurrent creation under high load ({@link #CONCURRENT_INSTANCE_COUNT} instances)</li>
+ *   <li>Instance independence (destroying one doesn't affect others)</li>
+ * </ul>
+ */
+public class MultiJniIntegTest {
+
+    private static final Logger log = LogManager.getLogger(MultiJniIntegTest.class);
+
+    private static final int DEFAULT_INSTANCE_COUNT = 3;
+    private static final int CONCURRENT_INSTANCE_COUNT = 500;
+    private static final int TEST_TIMEOUT_SECONDS = 15;
+
+    /**
+     * Tracks all created JNI instances for proper cleanup
+     * May contain nulls (to indicate the Jni instance was already freed)
+     */
+    private final List<NativeKinesisVideoProducerJni> jniInstances = new ArrayList<>();
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(TEST_TIMEOUT_SECONDS);
+
+    /**
+     * Initializes the test environment by loading the native JNI library.
+     */
+    @Before
+    public void setUp() {
+        try {
+            System.loadLibrary(PRODUCER_NATIVE_LIBRARY_NAME);
+            log.debug("Successfully loaded native library: {}", PRODUCER_NATIVE_LIBRARY_NAME);
+        } catch (final UnsatisfiedLinkError e) {
+            fail("JNI library not found. Ensure native library is built and available: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Cleans up all created JNI instances.
+     */
+    @After
+    public void tearDown() {
+        boolean allInstancesFreedSuccessfully = true;
+
+        for (int i = 0; i < this.jniInstances.size(); i++) {
+            try {
+                final NativeKinesisVideoProducerJni jni = this.jniInstances.get(i);
+                if (jni != null) {
+                    jni.free();
+                    log.debug("Successfully freed JNI instance {}", i);
+                }
+            } catch (final Exception e) {
+                log.error("Failed to free JNI instance {}: {}", i, e.getMessage());
+                allInstancesFreedSuccessfully = false;
+            }
+        }
+
+        this.jniInstances.clear();
+
+        assertTrue("Failed to free some JNI instances - check logs for details",
+                allInstancesFreedSuccessfully);
+    }
+
+    /**
+     * Validates that multiple JNI instances can be created sequentially without interference.
+     *
+     * <p>This test ensures that the JNI layer properly manages multiple producer instances
+     * within the same JVM, each with independent configurations and state.</p>
+     */
+    @Test
+    public void whenCreatingMultipleJniInstances_thenAllInstancesInitializedWithoutErrors() throws Exception {
+        // Given: Thread pools for async operations
+        final ScheduledExecutorService authExecutorService =
+                Executors.newScheduledThreadPool(DEFAULT_INSTANCE_COUNT);
+        final ScheduledExecutorService serviceCallbacksExecutorService =
+                Executors.newScheduledThreadPool(DEFAULT_INSTANCE_COUNT);
+
+        try {
+            // When: Creating multiple JNI instances with unique configurations
+            for (int i = 0; i < DEFAULT_INSTANCE_COUNT; i++) {
+                final NativeKinesisVideoProducerJni jni = createJniInstance(i, authExecutorService,
+                        serviceCallbacksExecutorService);
+                assertNotNull("JNI instance " + i + " should be created", jni);
+                this.jniInstances.add(jni);
+            }
+
+            // Then: All instances should be created successfully
+            assertEquals("All JNI instances should be created",
+                    DEFAULT_INSTANCE_COUNT, this.jniInstances.size());
+
+            // And: Each instance should be properly initialized and ready
+            initializeAllInstances();
+            verifyAllInstancesReady();
+
+        } finally {
+            shutdownExecutorServices(authExecutorService, serviceCallbacksExecutorService);
+        }
+    }
+
+    /**
+     * Validates that JNI instances can be created concurrently under high load.
+     *
+     * <p>This stress test creates {@value #CONCURRENT_INSTANCE_COUNT} instances simultaneously to verify
+     * thread safety and proper resource management in the native JNI layer. This simulates real-world
+     * scenarios where multiple clients are initialized concurrently.</p>
+     */
+    @Test
+    public void givenHighConcurrencyEnvironment_whenCreatingMultipleJniInstancesConcurrently_thenAllInstancesAreInitializedWithoutErrors() throws Exception {
+        // Given: High-concurrency execution environment
+        final String testContext = buildTestContext();
+        final ScheduledExecutorService authExecutorService =
+                Executors.newScheduledThreadPool(CONCURRENT_INSTANCE_COUNT);
+        final ScheduledExecutorService serviceCallbacksExecutorService =
+                Executors.newScheduledThreadPool(CONCURRENT_INSTANCE_COUNT);
+        final ExecutorService creationExecutor = Executors.newFixedThreadPool(CONCURRENT_INSTANCE_COUNT);
+
+        try {
+            // When: Creating instances concurrently with synchronized start
+            final List<Future<NativeKinesisVideoProducerJni>> creationFutures =
+                    submitConcurrentCreationTasks(testContext, authExecutorService,
+                            serviceCallbacksExecutorService, creationExecutor);
+
+            // Then: All instances should be created successfully
+            collectAndValidateConcurrentResults(creationFutures);
+
+            log.info("Successfully created {} concurrent JNI instances", CONCURRENT_INSTANCE_COUNT);
+
+        } finally {
+            shutdownExecutorServices(authExecutorService, serviceCallbacksExecutorService, creationExecutor);
+        }
+    }
+
+
+    /**
+     * Validates that JNI instances operate independently without affecting each other.
+     *
+     * <p>This test ensures that destroying one instance doesn't corrupt or interfere
+     * with other active instances, which is critical for robust multi-tenant operation.</p>
+     */
+    @Test
+    public void givenMultipleActiveJniInstances_whenDestroyingOneInstance_thenOtherInstancesRemainFunctional() throws Exception {
+        // Given: Multiple active JNI instances
+        whenCreatingMultipleJniInstances_thenAllInstancesInitializedWithoutErrors();
+        verifyAllInstancesReady();
+
+        // When: Destroying the middle instance
+        final int instanceToDestroy = 1;
+        log.info("Destroying JNI instance {} to test independence", instanceToDestroy);
+        this.jniInstances.get(instanceToDestroy).free();
+        this.jniInstances.set(instanceToDestroy, null);
+
+        // Then: Other instances should remain functional
+        assertTrue("Instance 0 should remain ready after destroying instance 1",
+                this.jniInstances.get(0).isReady());
+        assertTrue("Instance 2 should remain ready after destroying instance 1",
+                this.jniInstances.get(2).isReady());
+
+        // And: New instances can still be created (JNI layer is not corrupted)
+        final NativeKinesisVideoProducerJni newInstance = createSingleJniInstance(generateUniqueDeviceName("post-destruction-test"));
+        try {
+            assertTrue("New instance should be ready after previous destruction",
+                    newInstance.isReady());
+        } finally {
+            newInstance.free();
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    /**
+     * Initializes all created JNI instances with unique device configurations.
+     */
+    private void initializeAllInstances() throws Exception {
+        for (final NativeKinesisVideoProducerJni jniInstance : this.jniInstances) {
+            final String deviceName = generateUniqueDeviceName("sequential-test");
+            final DeviceInfo deviceInfo = createTestDeviceInfo(deviceName);
+            jniInstance.createSync(deviceInfo);
+        }
+    }
+
+    /**
+     * Verifies that all JNI instances are ready for operation.
+     */
+    private void verifyAllInstancesReady() {
+        for (int i = 0; i < this.jniInstances.size(); i++) {
+            assertTrue("JNI instance " + i + " should be ready",
+                    this.jniInstances.get(i).isReady());
+        }
+    }
+
+    /**
+     * Builds test context string for concurrent tests.
+     */
+    private String buildTestContext() {
+        return String.join("-", getClass().getSimpleName(), "testConcurrentJniCreation");
+    }
+
+    /**
+     * Submits concurrent JNI creation tasks with synchronized start.
+     */
+    private List<Future<NativeKinesisVideoProducerJni>> submitConcurrentCreationTasks(
+            final String testContext,
+            final ScheduledExecutorService authExecutor,
+            final ScheduledExecutorService serviceExecutor,
+            final ExecutorService creationExecutor) {
+
+        final List<Future<NativeKinesisVideoProducerJni>> futures = new ArrayList<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+
+        for (int i = 0; i < CONCURRENT_INSTANCE_COUNT; i++) {
+            final int index = i;
+            final Future<NativeKinesisVideoProducerJni> future = creationExecutor.submit(() -> {
+                try {
+                    startLatch.await(); // Synchronized start
+                    return createAndInitializeJniInstance(testContext, index, authExecutor, serviceExecutor);
+                } catch (final Exception e) {
+                    log.error("Failed to create concurrent JNI instance {}", index, e);
+                    fail("Failed to create concurrent JNI instance " + index + ": " + e.getMessage());
+                    return null;
+                }
+            });
+            futures.add(future);
+        }
+
+        // Start all tasks simultaneously
+        startLatch.countDown();
+        return futures;
+    }
+
+    /**
+     * Collects and validates results from concurrent creation tasks.
+     */
+    private void collectAndValidateConcurrentResults(
+            final List<Future<NativeKinesisVideoProducerJni>> futures) throws Exception {
+
+        for (int i = 0; i < CONCURRENT_INSTANCE_COUNT; i++) {
+            final NativeKinesisVideoProducerJni jni = futures.get(i).get(10, TimeUnit.SECONDS);
+            assertNotNull("Concurrent JNI instance " + i + " should be created", jni);
+            assertTrue("Concurrent JNI instance " + i + " should be ready", jni.isReady());
+            this.jniInstances.add(jni);
+        }
+
+        assertEquals("All concurrent instances should be created",
+                CONCURRENT_INSTANCE_COUNT, this.jniInstances.size());
+    }
+
+    /**
+     * Creates and initializes a single JNI instance for testing.
+     */
+    private NativeKinesisVideoProducerJni createSingleJniInstance(final String testContext) throws Exception {
+        final ScheduledExecutorService authExecutor = Executors.newScheduledThreadPool(1);
+        final ScheduledExecutorService serviceExecutor = Executors.newScheduledThreadPool(1);
+
+        try {
+            return createAndInitializeJniInstance(
+                    testContext, 0, authExecutor, serviceExecutor);
+        } finally {
+            shutdownExecutorServices(authExecutor, serviceExecutor);
+        }
+    }
+
+    /**
+     * Creates a JNI instance with the specified configuration.
+     */
+    private NativeKinesisVideoProducerJni createJniInstance(final int index,
+                                                            final ScheduledExecutorService authExecutor,
+                                                            final ScheduledExecutorService serviceExecutor) throws ProducerException {
+        final KinesisVideoCredentialsProvider credentialsProvider =
+                new StaticCredentialsProvider(new KinesisVideoCredentials("ak" + index, "sk" + index));
+
+        final KinesisVideoClientConfiguration configuration = KinesisVideoClientConfiguration.builder()
+                .withCredentialsProvider(credentialsProvider)
+                .build();
+
+        return new NativeKinesisVideoProducerJni(
+                new DefaultAuthCallbacks(credentialsProvider, authExecutor,
+                        LogManager.getLogger(NativeKinesisVideoProducerJni.class)),
+                new DefaultStorageCallbacks(),
+                new DefaultServiceCallbacksImpl(
+                        LogManager.getLogger(DefaultServiceCallbacksImpl.class),
+                        serviceExecutor, configuration, new JavaKinesisVideoServiceClient())
+        );
+    }
+
+    /**
+     * Creates and initializes a JNI instance with the specified configuration.
+     *
+     * @param index           used to identify the JNI instance
+     * @param testContext     used to identify the JNI instance
+     * @param authExecutor    used for the auth callbacks
+     * @param serviceExecutor used for the service callbacks
+     */
+    private NativeKinesisVideoProducerJni createAndInitializeJniInstance(
+            final String testContext, final int index,
+            final ScheduledExecutorService authExecutor,
+            final ScheduledExecutorService serviceExecutor) throws Exception {
+        assumeNotNull("testContext cannot be null", testContext);
+        assumeTrue("Index should not be negative", index >= 0);
+        assumeNotNull("authExecutor cannot be null", authExecutor);
+        assumeNotNull("serviceExecutor cannot be null", serviceExecutor);
+
+        final String accessKey = String.join("-", testContext, "ak", String.valueOf(index));
+        final String secretKey = String.join("-", testContext, "sk", String.valueOf(index));
+        final String deviceName = String.join("-", testContext, "device", String.valueOf(index));
+
+        final KinesisVideoCredentialsProvider credentialsProvider =
+                new StaticCredentialsProvider(new KinesisVideoCredentials(accessKey, secretKey));
+
+        final KinesisVideoClientConfiguration configuration = KinesisVideoClientConfiguration.builder()
+                .withCredentialsProvider(credentialsProvider)
+                .build();
+
+        final NativeKinesisVideoProducerJni jni = new NativeKinesisVideoProducerJni(
+                new DefaultAuthCallbacks(credentialsProvider, authExecutor,
+                        LogManager.getLogger(NativeKinesisVideoProducerJni.class)),
+                new DefaultStorageCallbacks(),
+                new DefaultServiceCallbacksImpl(
+                        LogManager.getLogger(DefaultServiceCallbacksImpl.class),
+                        serviceExecutor, configuration, new JavaKinesisVideoServiceClient())
+        );
+
+        final DeviceInfo deviceInfo = createTestDeviceInfo(deviceName);
+        jni.createSync(deviceInfo);
+
+        return jni;
+    }
+
+    /**
+     * Generates a unique device name for testing using the prefix.
+     */
+    @Nonnull
+    private String generateUniqueDeviceName(@Nonnull final String prefix) {
+        assumeNotNull("Prefix cannot be null!", prefix);
+
+        return String.join("-", prefix, String.valueOf(System.currentTimeMillis()),
+                UUID.randomUUID().toString().substring(0, 8));
+    }
+
+    /**
+     * Safely shuts down executor services with timeout.
+     */
+    private void shutdownExecutorServices(@Nonnull final ExecutorService... executors) {
+        assumeNotNull("Executors cannot be null!", executors);
+
+        for (final ExecutorService executor : executors) {
+            if (executor != null && !executor.isShutdown()) {
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                        log.error("Executor did not terminate within the timeout");
+                        fail("Executor did not terminate within the timeout");
+                    }
+                } catch (final Exception e) {
+                    log.error("Executor did not terminate gracefully", e);
+                    fail("Executor terminated with exception: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates test device information with standardized configuration.
+     *
+     * @param deviceName unique device identifier
+     * @return configured DeviceInfo for testing
+     */
+    @Nonnull
+    @SuppressWarnings("ConstantConditions")
+    private DeviceInfo createTestDeviceInfo(@Nonnull final String deviceName) {
+        assumeNotNull("Device name cannot be null", deviceName);
+
+        final int storageInfoVersion = 0;
+        final StorageInfo.DeviceStorageType storageType = StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM;
+        final long storageSizeBytes = 1024 * 1024 * 10; // 10 MB
+        final int spillRatio = 90;
+        final String rootDirectory = "/tmp";
+        final StorageInfo storageInfo = new StorageInfo(storageInfoVersion,
+                storageType,
+                storageSizeBytes,
+                spillRatio,
+                rootDirectory);
+
+        final int deviceInfoVersion = 0;
+        final Tag[] tags = null;
+        final int numStreams = 1;
+        return new DeviceInfo(deviceInfoVersion,
+                deviceName,
+                storageInfo,
+                numStreams,
+                tags);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Adding tests to confirm #245 integration

*Why was it changed?*
- Doing as two separate PRs to verify #245 is backwards-compatible (no impact to existing tests and CI/CD)

*How was it changed?*
- Create multiple client instances and stream concurrently
- Create new clients (500) in different threads to confirm thread-safety

*What testing was done for the changes?*
- Ran the new tests locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
