### PR TITLE
Additional null safety in the DefaultOnStreamDataAvailable

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/DefaultOnStreamDataAvailable.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/DefaultOnStreamDataAvailable.java
@@ -1,29 +1,43 @@
 package com.amazonaws.kinesisvideo.internal.mediasource;
 
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceSink;
 import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
 
+import javax.annotation.Nonnull;
+
+/**
+ * Forwards the received media data to the configured {@link MediaSourceSink}.
+ */
 public class DefaultOnStreamDataAvailable implements OnStreamDataAvailable {
+    @Nonnull
     final MediaSourceSink mediaSourceSink;
 
-    public DefaultOnStreamDataAvailable(final MediaSourceSink mediaSourceSink) {
+    @SuppressWarnings("ConstantConditions")
+    public DefaultOnStreamDataAvailable(@Nonnull final MediaSourceSink mediaSourceSink) {
+        Preconditions.checkArgument(mediaSourceSink != null, "MediaSourceSink cannot be null");
         this.mediaSourceSink = mediaSourceSink;
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
-    public void onFrameDataAvailable(final KinesisVideoFrame frame) throws KinesisVideoException {
+    public void onFrameDataAvailable(@Nonnull final KinesisVideoFrame frame) throws KinesisVideoException {
+        Preconditions.checkArgument(frame != null, "KinesisVideoFrame cannot be null");
+
         // ignore frame of size 0
         if (frame.getSize() == 0) {
             throw new KinesisVideoException("Empty frame is provided in frame data available.");
         }
 
-        mediaSourceSink.onFrame(frame);
+        this.mediaSourceSink.onFrame(frame);
     }
 
     @Override
-    public void onFragmentMetadataAvailable(final String metadataName, final String metadataValue,
+    public void onFragmentMetadataAvailable(@Nonnull final String metadataName, @Nonnull final String metadataValue,
                                             final boolean persistent) throws KinesisVideoException {
-        mediaSourceSink.onFragmentMetadata(metadataName, metadataValue, persistent);
+        Preconditions.checkArgument(metadataName != null, "Metadata name cannot be null");
+        Preconditions.checkArgument(metadataValue != null, "Metadata value cannot be null");
+        this.mediaSourceSink.onFragmentMetadata(metadataName, metadataValue, persistent);
     }
 }

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/OnStreamDataAvailable.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/OnStreamDataAvailable.java
@@ -3,16 +3,28 @@ package com.amazonaws.kinesisvideo.internal.mediasource;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
 import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
 
+import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
 
+/**
+ * In a media pipeline, the "source" (an object that generates or produces data), will forward
+ * the data to a "sink" (an object that receives the data).
+ *
+ * @see com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource
+ * @see com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceSink
+ * @see com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSource
+ * @see ProducerStreamSink
+ */
 public interface OnStreamDataAvailable {
-    default void onFrameDataAvailable(final ByteBuffer frame) throws KinesisVideoException {
+    default void onFrameDataAvailable(@Nonnull final ByteBuffer frame) throws KinesisVideoException {
         // no-op
     }
-    default void onFrameDataAvailable(final KinesisVideoFrame frame) throws KinesisVideoException {
+
+    default void onFrameDataAvailable(@Nonnull final KinesisVideoFrame frame) throws KinesisVideoException {
         // no-op
     }
-    default void onFragmentMetadataAvailable(final String metadataName, final String metadataValue,
+
+    default void onFragmentMetadataAvailable(@Nonnull final String metadataName, @Nonnull final String metadataValue,
                                              final boolean persistent) throws KinesisVideoException {
         // no-op
     }

--- a/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/ProducerStreamSink.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/mediasource/ProducerStreamSink.java
@@ -15,13 +15,18 @@ import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
  * Implementation of the MediaSourceSink interface that pushes frames and stream configuration
  * into an instance of KinesisVideoProducerStream.
  *
- * Primary purpose of this is to be used by the KinesisVideoClient implementation.
+ * <p>Primary purpose of this is to be used by the KinesisVideoClient implementation.</p>
  *
- * For example, when an instance of media source is being created or registered with KinesisVideoClient,
- * an instance of this sink is created, and the media source is initialized with this.
+ * <p>For example, when an instance of media source is being created or registered with KinesisVideoClient,
+ * an instance of this sink is created, and the media source is initialized with this.</p>
  *
- * It's then media source's job to produce the frames and push them into the sink
- * it has been initialized with
+ * <p>It's then media source's job to produce the frames and push them into the sink
+ * it has been initialized with.</p>
+ *
+ * @see MediaSourceSink
+ * @see com.amazonaws.kinesisvideo.client.KinesisVideoClient
+ * @see com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource
+ * @see OnStreamDataAvailable
  */
 public class ProducerStreamSink implements MediaSourceSink {
     private final KinesisVideoProducerStream producerStream;
@@ -47,7 +52,9 @@ public class ProducerStreamSink implements MediaSourceSink {
     }
 
     @Override
-    public void onFragmentMetadata(final String metadataName, final String metadataValue, final boolean persistent)
+    public void onFragmentMetadata(@Nonnull final String metadataName,
+                                   @Nonnull final String metadataValue,
+                                   final boolean persistent)
             throws KinesisVideoException {
         producerStream.putFragmentMetadata(metadataName, metadataValue, persistent);
     }

--- a/src/test/java/com/amazonaws/kinesisvideo/internal/mediasource/DefaultOnStreamDataAvailableTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/internal/mediasource/DefaultOnStreamDataAvailableTest.java
@@ -1,0 +1,161 @@
+package com.amazonaws.kinesisvideo.internal.mediasource;
+
+import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceSink;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DefaultOnStreamDataAvailableTest {
+
+    private static final Logger log = LogManager.getLogger(DefaultOnStreamDataAvailableTest.class);
+
+    /**
+     * Mock implementation that tracks when certain callbacks were invoked.
+     */
+    private static class TestMediaSourceSink implements MediaSourceSink {
+        boolean onFrameCalled = false;
+        boolean onFragmentMetadataCalled = false;
+        KinesisVideoFrame receivedFrame;
+        String receivedMetadataName;
+        String receivedMetadataValue;
+        boolean receivedPersistent;
+
+        @Override
+        public void onFrame(@Nonnull final KinesisVideoFrame frame) throws KinesisVideoException {
+            this.onFrameCalled = true;
+            this.receivedFrame = frame;
+        }
+
+        @Override
+        public void onCodecPrivateData(final byte[] codecPrivateData) throws KinesisVideoException {
+        }
+
+        @Override
+        public void onCodecPrivateData(final byte[] codecPrivateData,
+                                       final int trackId) throws KinesisVideoException {
+        }
+
+        @Override
+        public void onFragmentMetadata(@Nonnull final String metadataName,
+                                       @Nonnull final String metadataValue,
+                                       final boolean persistent) throws KinesisVideoException {
+            this.onFragmentMetadataCalled = true;
+            this.receivedMetadataName = metadataName;
+            this.receivedMetadataValue = metadataValue;
+            this.receivedPersistent = persistent;
+        }
+
+        @Override
+        public KinesisVideoProducerStream getProducerStream() {
+            return null;
+        }
+    }
+
+    /**
+     * Passing {@code null} to a required parameter.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNullMediaSourceSink_whenConstructing_thenThrowsException() {
+        new DefaultOnStreamDataAvailable(null);
+    }
+
+    /**
+     * Passing {@code null} to a required parameter.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNullFrame_whenOnFrameDataAvailable_thenThrowsException() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+        dataAvailable.onFrameDataAvailable((KinesisVideoFrame) null);
+    }
+
+    /**
+     * Passing zero-size frame.
+     */
+    @Test
+    public void givenEmptyFrame_whenOnFrameDataAvailable_thenThrowsKinesisVideoException() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+
+        final KinesisVideoFrame emptyFrame = new KinesisVideoFrame(0, 0,
+                0, 0, 0, ByteBuffer.allocate(0));
+
+        try {
+            dataAvailable.onFrameDataAvailable(emptyFrame);
+            fail("Expected KinesisVideoException");
+        } catch (final KinesisVideoException e) {
+            // Happy path
+            log.info("Received expected exception", e);
+        }
+    }
+
+    /**
+     * Happy path. Checking that it forwards the frame correctly.
+     */
+    @Test
+    public void givenValidFrame_whenOnFrameDataAvailable_thenCallsMediaSourceSink() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+
+        final KinesisVideoFrame validFrame = new KinesisVideoFrame(0, 0,
+                0, 0, 0, ByteBuffer.allocate(100));
+
+        dataAvailable.onFrameDataAvailable(validFrame);
+
+        assertTrue(sink.onFrameCalled);
+        assertEquals(validFrame, sink.receivedFrame);
+    }
+
+    /**
+     * Passing {@code null} to a required parameter.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNullMetadataName_whenOnFragmentMetadataAvailable_thenThrowsException() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+        dataAvailable.onFragmentMetadataAvailable(null, "value", true);
+    }
+
+    /**
+     * Passing {@code null} to a required parameter.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNullMetadataValue_whenOnFragmentMetadataAvailable_thenThrowsException() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+        dataAvailable.onFragmentMetadataAvailable("name", null, true);
+    }
+
+    /**
+     * Happy path. Checking that it forwards the metadata correctly.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void givenValidParameters_whenOnFragmentMetadataAvailable_thenCallsMediaSourceSink() throws KinesisVideoException {
+        final TestMediaSourceSink sink = new TestMediaSourceSink();
+        final DefaultOnStreamDataAvailable dataAvailable = new DefaultOnStreamDataAvailable(sink);
+        final String testMetadataName = "testName";
+        final String testMetadataValue = "testValue";
+
+        dataAvailable.onFragmentMetadataAvailable(testMetadataName, testMetadataValue, true);
+
+        assertTrue(sink.onFragmentMetadataCalled);
+        assertEquals(testMetadataName, sink.receivedMetadataName);
+        assertEquals(testMetadataValue, sink.receivedMetadataValue);
+        assertTrue(sink.receivedPersistent);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/internal/mediasource/OnStreamDataAvailableTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/internal/mediasource/OnStreamDataAvailableTest.java
@@ -1,0 +1,21 @@
+package com.amazonaws.kinesisvideo.internal.mediasource;
+
+import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class OnStreamDataAvailableTest {
+
+    @Test
+    public void givenDefaultImplementation_whenCallingMethods_thenDoNotThrowExceptions() throws KinesisVideoException {
+        final OnStreamDataAvailable implementation = new OnStreamDataAvailable() {
+        };
+
+        final ByteBuffer buffer = ByteBuffer.allocate(10);
+        implementation.onFrameDataAvailable(buffer);
+
+        implementation.onFragmentMetadataAvailable("test", "value", true);
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Enhanced null safety and parameter validation in DefaultOnStreamDataAvailable and OnStreamDataAvailable interface
- Added tests for the media source data handling components
- Updated ProducerStreamSink to include @Nonnull

*Why was it changed?*
- I noticed a NPE when calling the `ImageFileMediaSource.start()` without registering the media source with the client. Additional checks in the media source (to check for the initialization before start) will come in a future PR.
- Improve robustness and prevent runtime NullPointerException errors by adding explicit null checks with meaningful error messages. Note that `@NonNull` is a compile-time check.
- Enhance code documentation and maintainability.

*How was it changed?*
- CheckArgument validation for all non-null parameters in DefaultOnStreamDataAvailable
- Enhanced Javadoc documentation for the OnStreamDataAvailable interface

*What testing was done for the changes?*
- Ran the new tests locally
- Ran DemoAppMain locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
