### PR TITLE
Set the thread name for the media source generator thread

### DIFF
--- a/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java
+++ b/src/main/demo/com/amazonaws/kinesisvideo/demoapp/DemoAppMain.java
@@ -2,6 +2,7 @@ package com.amazonaws.kinesisvideo.demoapp;
 
 import com.amazonaws.kinesisvideo.client.IPVersionFilter;
 import com.amazonaws.kinesisvideo.client.KinesisVideoClient;
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.demoapp.contants.DemoTrackInfos;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSource;
 import com.amazonaws.kinesisvideo.common.exception.KinesisVideoException;
@@ -12,9 +13,11 @@ import com.amazonaws.kinesisvideo.java.mediasource.file.AudioVideoFileMediaSourc
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSource;
 import com.amazonaws.kinesisvideo.java.mediasource.file.ImageFileMediaSourceConfiguration;
 import com.amazonaws.regions.Regions;
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -69,7 +72,7 @@ public final class DemoAppMain {
 
             // create a media source. this class produces the data and pushes it into
             // Kinesis Video Producer lower level components
-            final MediaSource mediaSource = createImageFileMediaSource();
+            final MediaSource mediaSource = createImageFileMediaSource(STREAM_NAME);
 
             // Audio/Video sample is available for playback on HLS (Http Live Streaming)
             //final MediaSource mediaSource = createFileMediaSource();
@@ -98,7 +101,8 @@ public final class DemoAppMain {
      *
      * @return a MediaSource backed by local H264 frame files
      */
-    private static MediaSource createImageFileMediaSource() {
+    private static MediaSource createImageFileMediaSource(@Nonnull final String streamName) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(streamName), "streamName cannot be null or empty");
         final ImageFileMediaSourceConfiguration configuration =
                 new ImageFileMediaSourceConfiguration.Builder()
                         .fps(FPS_25)
@@ -108,6 +112,7 @@ public final class DemoAppMain {
                         .endFileIndex(END_FILE_INDEX)
                         //.contentType("video/hevc") // for h265
                         .allowStreamCreation(false)
+                        .frameGeneratorThreadName(streamName + "-frame-generator")
                         .build();
         final ImageFileMediaSource mediaSource = new ImageFileMediaSource(STREAM_NAME);
         mediaSource.configure(configuration);

--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFileMediaSourceConfiguration.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFileMediaSourceConfiguration.java
@@ -1,8 +1,12 @@
 package com.amazonaws.kinesisvideo.java.mediasource.file;
 
 
+import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.internal.client.mediasource.MediaSourceConfiguration;
 import com.amazonaws.kinesisvideo.producer.StreamCallbacks;
+import com.google.common.base.Strings;
+
+import javax.annotation.Nonnull;
 
 import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.VIDEO_CONTENT_TYPE;
 
@@ -17,6 +21,8 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
     private final boolean allowStreamCreation;
     private final long startTimeMs;
     private final StreamCallbacks streamCallbacks;
+    @Nonnull
+    private final String frameGeneratorThreadName;
 
     public ImageFileMediaSourceConfiguration(final Builder builder) {
         this.fps = builder.fps;
@@ -28,6 +34,7 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         this.allowStreamCreation = builder.allowStreamCreation;
         this.startTimeMs = builder.startTimeMs;
         this.streamCallbacks = builder.streamCallbacks;
+        this.frameGeneratorThreadName = builder.frameGeneratorThreadName;
     }
 
     public int getFps() {
@@ -74,6 +81,10 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         return streamCallbacks;
     }
 
+    public String getFrameGeneratorThreadName() {
+        return frameGeneratorThreadName;
+    }
+
     public static class Builder implements MediaSourceConfiguration.Builder<ImageFileMediaSourceConfiguration> {
 
         private int fps;
@@ -85,6 +96,8 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
         private boolean allowStreamCreation;
         private long startTimeMs = System.currentTimeMillis();
         private StreamCallbacks streamCallbacks = null;
+        @Nonnull
+        private String frameGeneratorThreadName = "ImageFileMediaSourceFrameGenerator";
 
         public Builder fps(final int fps) {
             this.fps = fps;
@@ -119,7 +132,7 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
             return this;
         }
 
-        public Builder allowStreamCreation(final Boolean allowStreamCreation) {
+        public Builder allowStreamCreation(final boolean allowStreamCreation) {
             this.allowStreamCreation = allowStreamCreation;
             return this;
         }
@@ -133,6 +146,12 @@ public class ImageFileMediaSourceConfiguration implements MediaSourceConfigurati
             this.streamCallbacks = streamCallbacks;
             return this;
         }
+
+        public Builder frameGeneratorThreadName(@Nonnull final String name) {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "frame generator thread name should not be null or empty.");
+            this.frameGeneratorThreadName = name;
+            return this;
+        };
 
         @Override
         public ImageFileMediaSourceConfiguration build() {

--- a/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/java/mediasource/file/ImageFrameSource.java
@@ -5,9 +5,11 @@ import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.internal.mediasource.OnStreamDataAvailable;
 
 import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -33,7 +35,8 @@ import static com.amazonaws.kinesisvideo.producer.Time.NANOS_IN_A_MILLISECOND;
 public class ImageFrameSource {
     public static final int METADATA_INTERVAL = 8;
     private static final long FRAME_DURATION_20_MS = 20L;
-    private final ExecutorService executor = Executors.newFixedThreadPool(1);
+    @Nonnull
+    private final ExecutorService executor;
     private final int fps;
     private final ImageFileMediaSourceConfiguration configuration;
 
@@ -52,6 +55,8 @@ public class ImageFrameSource {
         this.totalFiles = getTotalFiles(configuration.getStartFileIndex(), configuration.getEndFileIndex());
         this.fps = configuration.getFps();
         this.currentFrameTimestampMs = configuration.getStartTimeMs();
+        this.executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(configuration
+                .getFrameGeneratorThreadName()).build());
     }
 
     private int getTotalFiles(final int startIndex, final int endIndex) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added configurable thread naming for the media source generator thread in ImageFileMediaSource
- Updated ImageFileMediaSourceConfiguration to accept a custom thread name parameter
- Modified DemoAppMain to pass stream name for thread naming

*Why was it changed?*
- Improves debugging and monitoring capabilities by providing meaningful thread names
- Makes it easier to identify and track specific media source threads in multi-stream scenarios
- Enhances observability when troubleshooting performance or threading issues

*How was it changed?*
- Added `frameGeneratorThreadName` field to ImageFileMediaSourceConfiguration with validation
- Updated ImageFrameSource to use ThreadFactoryBuilder for custom thread naming
- Modified the executor service initialization to use the configured thread name
- Updated DemoAppMain to pass "{streamName}-frame-generator" as the thread name
- Ensured backward compatibility with existing configurations (default thread name provided)

*What testing was done for the changes?*
- Ran the DemoAppMain and made sure the thread was named (no longer 'pool-3-thread-1')

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
