### PR TITLE
Set the name for the putMedia threads

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/http/ParallelSimpleHttpClient.java
@@ -5,6 +5,7 @@ import com.amazonaws.kinesisvideo.client.KinesisVideoClientConfigurationDefaults
 import com.amazonaws.kinesisvideo.common.function.Consumer;
 import com.amazonaws.kinesisvideo.socket.SocketFactory;
 import com.amazonaws.kinesisvideo.util.LoggedExitRunnable;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -140,7 +141,7 @@ public final class ParallelSimpleHttpClient implements HttpClient {
 
     private void sendPayloadInBackground() {
         if (mBuilder.mSender != null) {
-            payloadSender = Executors.newFixedThreadPool(1);
+            payloadSender = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("PutMedia-Sending-" + mBuilder.mStreamName).build());
             payloadSender.execute(new LoggedExitRunnable("PutMedia-Sending-" + mBuilder.mStreamName) {
                 @Override
                 public void execute() {
@@ -167,7 +168,7 @@ public final class ParallelSimpleHttpClient implements HttpClient {
 
     private void receiveResponseInBackground() {
         if (mBuilder.mReceiver != null) {
-            responseReceiver = Executors.newFixedThreadPool(1);
+            responseReceiver = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("PutMedia-Receiving-" + mBuilder.mStreamName).build());
             responseReceiver.execute(new LoggedExitRunnable("PutMedia-Receiving-" + mBuilder.mStreamName) {
                 @Override
                 public void execute() {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Set descriptive names for putMedia threads in ParallelSimpleHttpClient

*Why was it changed?*
- Improves debugging and monitoring by providing meaningful thread names that include the stream name, making it easier to identify and troubleshoot specific stream operations in thread dumps and logs

*How was it changed?*
- Replaced Executors.newFixedThreadPool(1) with Executors.newSingleThreadExecutor() using ThreadFactoryBuilder to set custom thread names
- Added "PutMedia-Sending-{streamName}" and "PutMedia-Receiving-{streamName}" naming patterns for the respective thread pools

*What testing was done for the changes?*
- Ran the DemoAppMain with #253 and didn't see any more `pool-3-thread-1` or `pool-4-thread-1` anymore:

<img width="2016" height="804" alt="image" src="https://github.com/user-attachments/assets/555b9a19-3069-4dbc-9f86-b46b934f3457" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
