### PR TITLE
Add additional JVM exception checks

### DIFF
--- a/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
+++ b/jni/com/amazonaws/kinesis/video/producer/jni/KinesisVideoClientWrapper.cpp
@@ -227,6 +227,10 @@ void KinesisVideoClientWrapper::getKinesisVideoMetrics(jobject kinesisVideoMetri
                         metrics.totalContentViewsSize,
                         metrics.totalFrameRate,
                         metrics.totalTransferRate);
+    CHK_JVM_EXCEPTION(env);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
 }
 
 void KinesisVideoClientWrapper::getKinesisVideoStreamMetrics(jlong streamHandle, jobject kinesisVideoStreamMetrics)
@@ -292,6 +296,10 @@ void KinesisVideoClientWrapper::getKinesisVideoStreamMetrics(jlong streamHandle,
                         metrics.currentViewDuration,
                         metrics.currentFrameRate,
                         metrics.currentTransferRate);
+    CHK_JVM_EXCEPTION(env);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
 }
 
 STREAM_HANDLE KinesisVideoClientWrapper::createKinesisVideoStream(jobject streamInfo)
@@ -567,6 +575,7 @@ void KinesisVideoClientWrapper::getKinesisVideoStreamData(jlong streamHandle, jl
                         setterMethodId,
                         filledSize,
                         isEos);
+    CHK_JVM_EXCEPTION(env);
 
 CleanUp:
 
@@ -2389,6 +2398,7 @@ STATUS KinesisVideoClientWrapper::getAuthInfo(jmethodID methodId, PBYTE* ppCert,
 
     // Call the Java func
     jAuthInfoObj = env->CallObjectMethod(pWrapper->getJavaObjectRef(), methodId);
+    CHK_JVM_EXCEPTION(env);
     if (jAuthInfoObj == NULL) {
         DLOGE("Failed to get the object for the AuthInfo object. methodId %s", methodId);
         retStatus = STATUS_INVALID_ARG;
@@ -2684,7 +2694,7 @@ VOID KinesisVideoClientWrapper::logPrintFunc(UINT32 level, PCHAR tag, PCHAR fmt,
                       << "Level: " << level << ", Tag: " << (tag ? tag : "NULL")
                       << ", Message: " << buffer << std::endl;
 
-            CHK(FALSE, STATUS_SUCCESS);
+            return;
         }
         CHK(pWrapper->getJVM() != NULL, STATUS_SUCCESS);
 
@@ -2759,7 +2769,7 @@ VOID KinesisVideoClientWrapper::logPrintFunc(UINT32 level, PCHAR tag, PCHAR fmt,
         }
 
         // Detach the thread if we have attached it to JVM
-        if (attached && pWrapper != nullptr) {
+        if (attached && pWrapper != nullptr && pWrapper->getJVM() != nullptr) {
             pWrapper->getJVM()->DetachCurrentThread();
         }
     });


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add additional JVM checks in the native layer

*Why was it changed?*
- Ran `DemoAppMain` with `-Xcheck:jni` and these warnings showed up. Resolving these.

```log
WARNING in native method: JNI call made without checking exceptions when required to from CallObjectMethodV
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.createKinesisVideoClient(Native Method)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.create(NativeKinesisVideoProducerJni.java:268)
	- locked <0x00000007ffa667c0> (a java.lang.Object)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.createSync(NativeKinesisVideoProducerJni.java:280)
	at com.amazonaws.kinesisvideo.internal.producer.jni.NativeKinesisVideoProducerJni.createSync(NativeKinesisVideoProducerJni.java:241)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.initializeNewKinesisVideoProducer(NativeKinesisVideoClient.java:263)
	at com.amazonaws.kinesisvideo.internal.client.NativeKinesisVideoClient.initialize(NativeKinesisVideoClient.java:141)
	at com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory.createKinesisVideoClient(KinesisVideoJavaClientFactory.java:174)
	at com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory.createKinesisVideoClient(KinesisVideoJavaClientFactory.java:147)
	at com.amazonaws.kinesisvideo.java.client.KinesisVideoJavaClientFactory.createKinesisVideoClient(KinesisVideoJavaClientFactory.java:100)
	at com.amazonaws.kinesisvideo.demoapp.DemoAppMain.main(DemoAppMain.java:66)
```


*How was it changed?*
- Add `CHK_JVM_EXCEPTION` macro to the areas, which does `env->ExceptionCheck()`.

*What testing was done for the changes?*
- Run DemoAppMain with the `-Xcheck:jni` with the changes, and verified no more warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
