### PR TITLE
Rebase #265 to latest develop (missing frames in a track tests)

### DIFF
--- a/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/internal/service/DefaultServiceCallbacksImpl.java
@@ -19,6 +19,7 @@ import com.amazonaws.kinesisvideo.producer.StreamDescription;
 import com.amazonaws.kinesisvideo.producer.Tag;
 import com.amazonaws.kinesisvideo.producer.Time;
 import com.amazonaws.kinesisvideo.util.LoggedExitRunnable;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
@@ -53,6 +54,9 @@ import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RESOURCE_NOT_F
  */
 public class DefaultServiceCallbacksImpl implements ServiceCallbacks {
     private class CompletionCallback implements Consumer<Exception> {
+
+        private final Logger log = LogManager.getLogger(CompletionCallback.class);
+
         private final KinesisVideoProducerStream stream;
         private final AckConsumer ackConsumer;
         private final long uploadHandle;

--- a/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFragmentAck.java
+++ b/src/main/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFragmentAck.java
@@ -3,6 +3,8 @@ package com.amazonaws.kinesisvideo.producer;
 import com.amazonaws.kinesisvideo.common.preconditions.Preconditions;
 import com.amazonaws.kinesisvideo.util.CalledByNativeCode;
 import com.amazonaws.kinesisvideo.util.StreamInfoConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
@@ -41,6 +43,9 @@ import javax.annotation.concurrent.ThreadSafe;
 @Immutable
 @ThreadSafe
 public class KinesisVideoFragmentAck {
+
+    private static final Logger log = LogManager.getLogger(KinesisVideoFragmentAck.class);
+
     /**
      * The current version of the fragment acknowledgement struct in the native layer.
      */
@@ -131,7 +136,12 @@ public class KinesisVideoFragmentAck {
 
         Preconditions.checkArgument(ackType != null, "ackType cannot be null");
         Preconditions.checkArgument(sequenceNumber != null, "sequenceNumber cannot be null");
-        Preconditions.checkArgument(!sequenceNumber.isEmpty(), "sequenceNumber cannot be empty");
+
+        // Some error acks don't come with a sequence number (e.g. INVALID_MKV_DATA)
+        if (sequenceNumber.isEmpty()) {
+            log.warn("Received empty sequence number! AckType: {}, Timestamp: {}, Result: {}",
+                    ackType, timestamp, result);
+        }
 
         this.ackType = ackType;
         this.timestamp = timestamp;

--- a/src/test/java/com/amazonaws/kinesisvideo/common/DontRecoverOnErrorTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/DontRecoverOnErrorTest.java
@@ -1,0 +1,438 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.java.service.CachedInfoMultiAuthServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.producer.ClientInfo;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.FragmentAckType;
+import com.amazonaws.kinesisvideo.producer.FrameOrderMode;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFragmentAck;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.MkvTrackInfoType;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.kinesisvideo.producer.Time;
+import com.amazonaws.kinesisvideo.producer.TrackInfo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.APIName;
+import com.amazonaws.services.kinesisvideo.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_BITRATE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_REPLAY_DURATION;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_STALENESS_DURATION;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_TIMESCALE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.MAX_LATENCY_ZERO;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.NOT_ADAPTIVE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.NO_KMS_KEY_ID;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RECALCULATE_METRICS;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RELATIVE_TIMECODES;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.REQUEST_FRAGMENT_ACKS;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RETENTION_ONE_HOUR;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.USE_FRAME_TIMECODES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Integration test that verifies the producer behavior when RECOVER_ON_ERROR is disabled.
+ * <p>
+ * This test configures the stream using the RECOVER_ON_ERROR setting to be false, meaning that
+ * after PutMedia completes with an error, it doesn't respawn a new PutMedia anymore.
+ */
+public class DontRecoverOnErrorTest extends ProducerTestBase {
+
+    private static final Logger log = LogManager.getLogger(DontRecoverOnErrorTest.class);
+
+    private static final boolean DO_NOT_RECOVER_ON_FAILURE = false;
+
+    private static final int STORAGE_INFO_VERSION_ZERO = 0;
+    private static final int ONE_SECOND_HUNDREDS_OF_NANOS = 1000 * 10000;
+    private static final int TEN_SECONDS_HUNDREDS_OF_NANOS = 10 * ONE_SECOND_HUNDREDS_OF_NANOS;
+
+    private static final int STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED = 0x52000085;
+
+    /**
+     * List of stream names created during tests that need to be cleaned up.
+     */
+    private final List<String> createdStreams = new ArrayList<>();
+
+    /**
+     * Sets up the test environment before each test method.
+     * This will fail if the JNI (java.library.path) can't be loaded.
+     */
+    @Before
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ExtractMethodRecommender"})
+    public void setUp() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+
+        final int deviceInfoVersionOne = 1;
+        final long fourGBStorageSizeInBytes = 4L * 1024 * 1024 * 1024;
+        final int oneStream = 1;
+        final String clientId = "TestClient";
+
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = TEN_SECONDS_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = TEN_SECONDS_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.DEFAULT_LOG_LEVEL;
+
+        // ClientInfo V1 fields
+        final boolean doLogMetrics = true;
+
+        // ClientInfo V2 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final ClientInfo.AutomaticStreamingFlags automaticStreamingFlags = ClientInfo.AutomaticStreamingFlags.AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS;
+        final long reservedCallbackPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        // ClientInfo V3 fields
+        final long serviceCallCompletionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long serviceCallConnectionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        final ClientInfo clientInfoV3 = new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout,
+                offlineBufferAvailabilityTimeout, logLevel, doLogMetrics, automaticStreamingFlags,
+                serviceCallCompletionTimeout, serviceCallConnectionTimeout);
+
+        createCachedProducer(new DeviceInfo(deviceInfoVersionOne,
+                DontRecoverOnErrorTest.class.getSimpleName(),
+                new StorageInfo(STORAGE_INFO_VERSION_ZERO,
+                        StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM,
+                        fourGBStorageSizeInBytes,
+                        SPILL_RATIO_PERCENT,
+                        ""),
+                oneStream, null, clientId, clientInfoV3));
+        assumeTrue("ServiceCallbacks should be caching type!", this.serviceCallbacks instanceof CachedInfoMultiAuthServiceCallbacksImpl);
+    }
+
+    /**
+     * Cleans up resources after each test method.
+     *
+     * <p>This method:</p>
+     * <ul>
+     *   <li>Clears all tracking lists and stream information</li>
+     *   <li>Frees all streams and producer resources</li>
+     * </ul>
+     */
+    @After
+    public void tearDown() {
+        boolean failure = false;
+
+        try {
+            stopStreams();
+        } catch (final Exception e) {
+            failure = true;
+            log.error("Failed to stop streams {}", this.createdStreams, e);
+        }
+
+        try {
+            freeStreams();
+        } catch (final Exception e) {
+            failure = true;
+            log.error("Failed to free streams {}", this.createdStreams, e);
+        }
+
+        final AmazonKinesisVideo awsSdkKinesisVideoClient = AmazonKinesisVideoClient.builder().build();
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        for (final String streamName : this.createdStreams) {
+            final String finalStreamName = prefix + streamName;
+            try {
+                final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest().withStreamName(finalStreamName);
+                final DescribeStreamResult describeStreamResult = awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+
+                final DeleteStreamRequest deleteStreamRequest = new DeleteStreamRequest()
+                        .withStreamARN(describeStreamResult.getStreamInfo().getStreamARN())
+                        .withCurrentVersion(describeStreamResult.getStreamInfo().getVersion());
+                awsSdkKinesisVideoClient.deleteStream(deleteStreamRequest);
+            } catch (final Exception e) {
+                failure = true;
+                log.error("Failed to delete the stream: {}", finalStreamName, e);
+            }
+        }
+
+        this.createdStreams.clear();
+
+        assertFalse("An exception happened during cleanup!", failure);
+    }
+
+    /**
+     * Creates test frame data for streaming.
+     *
+     * @return byte array containing test frame data
+     */
+    private byte[] createTestFrameData() {
+        final byte[] frameData = new byte[TEST_FRAME_SIZE_BYTES];
+        for (int i = 0; i < frameData.length; i++) {
+            frameData[i] = (byte) (i % 256);
+        }
+        return frameData;
+    }
+
+    /**
+     * Creates a stream with the given streamName (plus prefix) and tracks.
+     * Also adds the info to the cache.
+     */
+    @SuppressWarnings("ConstantConditions")
+    protected KinesisVideoProducerStream createTestStream(@Nonnull final String streamName,
+                                                          @Nonnull final TrackInfo[] tracks) {
+        assumeTrue("StreamName cannot be null", streamName != null);
+        assumeTrue("Tracks cannot be null", tracks != null);
+        KinesisVideoProducerStream kinesisVideoProducerStream = null;
+
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        final String finalStreamName = prefix + streamName;
+        prepareStream(finalStreamName);
+
+        final CachedInfoMultiAuthServiceCallbacksImpl cache = (CachedInfoMultiAuthServiceCallbacksImpl) this.serviceCallbacks;
+
+        try {
+            final AmazonKinesisVideo kinesisVideoClient = AmazonKinesisVideoClientBuilder.defaultClient();
+
+            // Cache DescribeStream
+            final DescribeStreamResult describeStreamResult = kinesisVideoClient.describeStream(new DescribeStreamRequest().withStreamName(finalStreamName));
+            cache.addStreamInfoToCache(finalStreamName, describeStreamResult);
+
+            // Cache GetDataEndpoint
+            final GetDataEndpointResult getDataEndpointResult = kinesisVideoClient.getDataEndpoint(new GetDataEndpointRequest()
+                    .withStreamName(finalStreamName)
+                    .withAPIName(APIName.PUT_MEDIA)
+            );
+            cache.addStreamingEndpointToCache(finalStreamName, getDataEndpointResult.getDataEndpoint());
+
+            // Cache GetStreamingToken
+            cache.addCredentialsProviderToCache(finalStreamName, DefaultAWSCredentialsProviderChain.getInstance());
+        } catch (final Exception e) {
+            log.error("Failed to fetch the stream details: {}", finalStreamName, e);
+            fail();
+        }
+
+        final StreamInfo streamInfo = new StreamInfo(
+                StreamInfo.STREAM_INFO_CURRENT_VERSION,
+                finalStreamName,
+                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME,
+                "audio/PCM",
+                NO_KMS_KEY_ID,
+                RETENTION_ONE_HOUR,
+                NOT_ADAPTIVE,
+                MAX_LATENCY_ZERO,
+                1L * Time.HUNDREDS_OF_NANOS_IN_A_SECOND, // 1 second GOP
+                false, // no keyframe fragmentation
+                USE_FRAME_TIMECODES,
+                RELATIVE_TIMECODES,
+                REQUEST_FRAGMENT_ACKS,
+                DO_NOT_RECOVER_ON_FAILURE,
+                DEFAULT_BITRATE,
+                this.fps_,
+                TEN_SECONDS_HUNDREDS_OF_NANOS, // 10s buffer
+                DEFAULT_REPLAY_DURATION,
+                DEFAULT_STALENESS_DURATION,
+                DEFAULT_TIMESCALE,
+                RECALCULATE_METRICS,
+                new Tag[]{
+                        new Tag("device", "Test Device"),
+                        new Tag("stream", "Test Stream")},
+                StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_FLAG_NONE,
+                null,
+                tracks,
+                FrameOrderMode.FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_DTS_ONE_MS_COMPENSATE,
+                StreamInfo.StorePressurePolicy.CONTENT_STORE_PRESSURE_POLICY_DROP_TAIL_ITEM,
+                this.allowStreamCreation
+        );
+
+        try {
+            // Note: Using createStream (not sync version)
+            kinesisVideoProducerStream = this.kinesisVideoProducer.createStream(streamInfo, this.streamCallbacks);
+        } catch (final Exception e) {
+            log.error("Failed to create the stream: {}", finalStreamName, e);
+            fail();
+        }
+
+        return kinesisVideoProducerStream;
+    }
+
+    /**
+     * Tests that when RECOVER_ON_ERROR is disabled, the producer stops streaming after encountering
+     * a track timestamp delta error and does not attempt to recover.
+     *
+     * <p><strong>Test Flow:</strong></p>
+     * <ol>
+     *   <li>Setup 1 stream with 2 audio tracks and RECOVER_ON_ERROR disabled</li>
+     *   <li>Stream normally for 5 seconds with both tracks</li>
+     *   <li>Stop sending frames for track 2, causing timestamp delta errors for 40s</li>
+     *   <li>Resume sending frames for both tracks for 20s</li>
+     * </ol>
+     *
+     * <p><strong>Expected Behavior:</strong></p>
+     * <ul>
+     *   <li>The stream should not recover and no new PutMedia session should be created</li>
+     *   <li>ACKs should only be received for the initial streaming period</li>
+     * </ul>
+     */
+    @Test
+    public void test_whenCameraUnreachableScenario_thenWhenCameraIsReachableAgainItRecovers()
+            throws InterruptedException {
+        final String testName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String testStreamName = "MissingFramesIntegTest_" + testName + "_" + System.currentTimeMillis();
+
+        final TrackInfo[] tracks = new TrackInfo[]{
+                new TrackInfo(1, "A_MS/ACM", "audio-track-1", null, MkvTrackInfoType.AUDIO),
+                new TrackInfo(2, "A_MS/ACM", "audio-track-2", null, MkvTrackInfoType.AUDIO)
+        };
+
+        // 1 - Create a Kinesis Video Stream with two tracks
+        final KinesisVideoProducerStream stream = createTestStream(testStreamName, tracks);
+        assertNotNull("Stream should be created", stream);
+        this.createdStreams.add(testStreamName);
+
+        // 2 - Start streaming normally for 5s
+        final int framesCorrectly = 250;
+        final int framesAfterFailing = 2250;
+        final int fps = 50;
+        long currentFrameTs = System.currentTimeMillis();
+        final byte[] frameData = createTestFrameData();
+
+        for (int frameIndex = 0; frameIndex < framesCorrectly; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    this.frameDuration_,
+                    ByteBuffer.wrap(frameData),
+                    (frameIndex % 2) + 1
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                log.error(e);
+                fail("Failed to put a normal frame into the stream! " + e);
+            }
+
+            // Make sure no errors via streamErrorReport callback
+            if (this.errorStatus_ != 0) {
+                log.error("Received an unexpected stream error: {}", Long.toHexString(this.errorStatus_));
+                fail("Received an unexpected stream error: " + Long.toHexString(this.errorStatus_));
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // 3 - Interrupt the 2nd track for 40s
+        for (int frameIndex = framesCorrectly; frameIndex < framesAfterFailing + framesCorrectly; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    1000 / fps * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    ByteBuffer.wrap(frameData),
+                    1
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                assertEquals(STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED, e.getStatusCode());
+            }
+
+            // Make sure no errors received via streamErrorReport callback
+            if (this.errorStatus_ != 0) {
+                log.info("Received an expected stream error: 0x{}", Long.toHexString(this.errorStatus_));
+                fail("Received an expected stream error: 0x" + Long.toHexString(this.errorStatus_));
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // Stream normally (recover) for 20s
+        for (int frameIndex = framesAfterFailing + framesCorrectly; frameIndex < framesAfterFailing + framesCorrectly + 1000; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    1000 / fps * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    ByteBuffer.wrap(frameData),
+                    ((frameIndex + 1) % 2) + 1 // To alternate the track order (to start with the 2nd track to immediately allow frames in again
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                log.error(e);
+                fail("Failed to put a normal frame into the stream! " + e);
+            }
+
+            // Make sure no errors via streamErrorReport callback
+            if (this.errorStatus_ != 0) {
+                System.out.println("Received an unexpected stream error: 0x" + Long.toHexString(this.errorStatus_));
+                fail("Received an unexpected stream error: 0x" + Long.toHexString(this.errorStatus_));
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // Wait additional time for any delayed error callbacks
+        log.debug("Waiting for all acks to come in...");
+        Thread.sleep(5000);
+
+        System.out.println(this.receivedFragmentAcks_);
+
+        // 3 - Verify no errors
+        assertEquals("Should have received no errors. " +
+                "Error status: 0x" + Long.toHexString(this.errorStatus_), 0, this.errorStatus_);
+
+        final long persistedAcksCount = this.receivedFragmentAcks_.stream()
+                .filter(ack -> ack.getAckType().getIntType() == FragmentAckType.FRAGMENT_ACK_TYPE_PERSISTED)
+                .count();
+
+        assertTrue("Didn't receive any PERSISTED ACKs. Received: " + this.receivedFragmentAcks_, persistedAcksCount > 0);
+
+
+        // 4 - Verify no acks after the first PutMedia ended (didn't spawn up a 2nd PutMedia)
+        final long largestAckTimestamp = this.receivedFragmentAcks_.stream()
+                .map(KinesisVideoFragmentAck::getTimestamp)
+                .sorted()
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+
+        final long expectedLargestTimestampMs = framesCorrectly / fps * 1000;
+        assertTrue("A 2nd PutMedia session should not have happened! " + this.receivedFragmentAcks_ + " - The expected largest timestamp was: " + expectedLargestTimestampMs,
+                largestAckTimestamp <= expectedLargestTimestampMs);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/common/DontRecoverOnErrorTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/DontRecoverOnErrorTest.java
@@ -360,9 +360,14 @@ public class DontRecoverOnErrorTest extends ProducerTestBase {
                     1
             );
 
+            // The first few frames will get added to the content view successfully,
+            // but after the max timestamp delta, PIC will reject frames until it's not missing a track anymore
+            // The PutMedia connection will get closed by the service but will not be re-opened by the SDK
+            // because of the recoverOnError=false flag
             try {
                 stream.putFrame(frame);
             } catch (final ProducerException e) {
+                // The frame does not get added to the content view
                 assertEquals(STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED, e.getStatusCode());
             }
 
@@ -377,6 +382,10 @@ public class DontRecoverOnErrorTest extends ProducerTestBase {
         }
 
         // Stream normally (recover) for 20s
+        // We should be able to continue to submit frames into the content view, since
+        // the delta between the latest frame in each track is less than the threshold.
+        // Since the PutMedia connection isn't open, there is no PutMedia-sender thread
+        // that is emptying the content view
         for (int frameIndex = framesAfterFailing + framesCorrectly; frameIndex < framesAfterFailing + framesCorrectly + 1000; frameIndex++) {
             final long timestampUs = currentFrameTs * 1000;
 
@@ -390,6 +399,11 @@ public class DontRecoverOnErrorTest extends ProducerTestBase {
                     ((frameIndex + 1) % 2) + 1 // To alternate the track order (to start with the 2nd track to immediately allow frames in again
             );
 
+            // The content view is configured with the CONTENT_STORE_PRESSURE_POLICY_DROP_TAIL_ITEM policy,
+            // meaning that it will drop the oldest item. The content view should have content near expiry
+            // since there are frames submitted before the delta kicked in. putFrame on a "full" content view
+            // will throw an exception if the policy is set to CONTENT_STORE_PRESSURE_POLICY_OOM. Since it's
+            // using the other policy, we are expecting the frame submission to the content view to be successful.
             try {
                 stream.putFrame(frame);
             } catch (final ProducerException e) {

--- a/src/test/java/com/amazonaws/kinesisvideo/common/MissingFramesIntegTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/MissingFramesIntegTest.java
@@ -1,0 +1,451 @@
+package com.amazonaws.kinesisvideo.common;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.kinesisvideo.internal.producer.KinesisVideoProducerStream;
+import com.amazonaws.kinesisvideo.java.service.CachedInfoMultiAuthServiceCallbacksImpl;
+import com.amazonaws.kinesisvideo.producer.ClientInfo;
+import com.amazonaws.kinesisvideo.producer.DeviceInfo;
+import com.amazonaws.kinesisvideo.producer.FragmentAckType;
+import com.amazonaws.kinesisvideo.producer.FrameOrderMode;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFragmentAck;
+import com.amazonaws.kinesisvideo.producer.KinesisVideoFrame;
+import com.amazonaws.kinesisvideo.producer.MkvTrackInfoType;
+import com.amazonaws.kinesisvideo.producer.ProducerException;
+import com.amazonaws.kinesisvideo.producer.StorageInfo;
+import com.amazonaws.kinesisvideo.producer.StreamInfo;
+import com.amazonaws.kinesisvideo.producer.Tag;
+import com.amazonaws.kinesisvideo.producer.Time;
+import com.amazonaws.kinesisvideo.producer.TrackInfo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideo;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient;
+import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClientBuilder;
+import com.amazonaws.services.kinesisvideo.model.APIName;
+import com.amazonaws.services.kinesisvideo.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesisvideo.model.DescribeStreamResult;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointRequest;
+import com.amazonaws.services.kinesisvideo.model.GetDataEndpointResult;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_BITRATE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_REPLAY_DURATION;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_STALENESS_DURATION;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.DEFAULT_TIMESCALE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.MAX_LATENCY_ZERO;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.NOT_ADAPTIVE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.NO_KMS_KEY_ID;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RECALCULATE_METRICS;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RECOVER_ON_FAILURE;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RELATIVE_TIMECODES;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.REQUEST_FRAGMENT_ACKS;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.RETENTION_ONE_HOUR;
+import static com.amazonaws.kinesisvideo.util.StreamInfoConstants.USE_FRAME_TIMECODES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Integration test for a MediaSource that has a flaky 2nd track (inconsistently produces frames).
+ *
+ * <p>The KVS backend requires the tracks in each fragment, to be consistent throughout the PutMedia connection.
+ * When one track stops producing frames, the service will close the PutMedia connection with 4011: FRAMES_MISSING_FOR_TRACK
+ * error ack. Retry behavior: The SDK will drop the current fragment, open a new PutMedia connection, and resume
+ * from the next fragment. This continues until the 2nd track recovers. Ideally, the application should stop the stream
+ * until the tracks are consistent again, then start the stream back up to avoid unnecessary retries.</p>
+ *
+ * <p><strong>Test Scenarios:</strong></p>
+ * <ul>
+ *   <li>{@link #test_whenCameraUnreachableScenario_thenWhenCameraIsReachableAgainItRecovers()}:
+ *      Testing stream recovery once the 2nd track resumes producing frames again and without stopping the stream</li>
+ * </ul>
+ */
+public class MissingFramesIntegTest extends ProducerTestBase {
+
+    private static final Logger log = LogManager.getLogger(MissingFramesIntegTest.class);
+    private static final int STORAGE_INFO_VERSION_ZERO = 0;
+    private static final int ONE_SECOND_HUNDREDS_OF_NANOS = 1000 * 10000;
+    private static final int TWENTY_SECONDS_HUNDREDS_OF_NANOS = 20 * ONE_SECOND_HUNDREDS_OF_NANOS;
+
+    private static final int PUT_MEDIA_ERROR_ACK_FRAMES_MISSING_FOR_TRACK = 4011;
+    private static final long STATUS_ACK_ERR_FRAMES_MISSING_FOR_TRACK = 0x5200007d;
+    private static final long STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED = 0x52000085;
+
+    /**
+     * List of stream names created during tests that need to be cleaned up.
+     */
+    private final List<String> createdStreams = new ArrayList<>();
+
+    /**
+     * Sets up the test environment before each test method.
+     * This will fail if the JNI (java.library.path) can't be loaded.
+     */
+    @Before
+    @SuppressWarnings({"UnnecessaryLocalVariable", "ExtractMethodRecommender"})
+    public void setUp() {
+        final boolean jniLoaded = isJNILoaded();
+        if (!jniLoaded) {
+            fail("JNI library not found.");
+        }
+
+        final int deviceInfoVersionOne = 1;
+        final long fourGBStorageSizeInBytes = 4L * 1024 * 1024 * 1024;
+        final int oneStream = 1;
+        final String clientId = "TestClient";
+
+        final long createClientTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long createStreamTimeout = TWENTY_SECONDS_HUNDREDS_OF_NANOS;
+        final long stopStreamTimeout = TWENTY_SECONDS_HUNDREDS_OF_NANOS;
+        final long offlineBufferAvailabilityTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final int logLevel = ClientInfo.DEFAULT_LOG_LEVEL;
+
+        // ClientInfo V1 fields
+        final boolean doLogMetrics = true;
+
+        // ClientInfo V2 fields
+        final long metricsLoggingPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final ClientInfo.AutomaticStreamingFlags automaticStreamingFlags = ClientInfo.AutomaticStreamingFlags.AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS;
+        final long reservedCallbackPeriod = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        // ClientInfo V3 fields
+        final long serviceCallCompletionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+        final long serviceCallConnectionTimeout = ONE_SECOND_HUNDREDS_OF_NANOS;
+
+        final ClientInfo clientInfoV3 = new ClientInfo(createClientTimeout, createStreamTimeout, stopStreamTimeout,
+                offlineBufferAvailabilityTimeout, logLevel, doLogMetrics, automaticStreamingFlags,
+                serviceCallCompletionTimeout, serviceCallConnectionTimeout);
+
+        createCachedProducer(new DeviceInfo(deviceInfoVersionOne,
+                MissingFramesIntegTest.class.getSimpleName(),
+                new StorageInfo(STORAGE_INFO_VERSION_ZERO,
+                        StorageInfo.DeviceStorageType.DEVICE_STORAGE_TYPE_IN_MEM,
+                        fourGBStorageSizeInBytes,
+                        SPILL_RATIO_PERCENT,
+                        ""),
+                oneStream, null, clientId, clientInfoV3));
+        assumeTrue("ServiceCallbacks should be caching type!", this.serviceCallbacks instanceof CachedInfoMultiAuthServiceCallbacksImpl);
+    }
+
+    /**
+     * Cleans up resources after each test method.
+     *
+     * <p>This method:</p>
+     * <ul>
+     *   <li>Clears all tracking lists and stream information</li>
+     *   <li>Frees all streams and producer resources</li>
+     * </ul>
+     */
+    @After
+    public void tearDown() {
+        boolean failure = false;
+        try {
+            stopStreams();
+        } catch (final Exception e) {
+            failure = true;
+            log.error("Failed to stop streams {}", this.createdStreams, e);
+        }
+
+        try {
+            freeStreams();
+        } catch (final Exception e) {
+            failure = true;
+            log.error("Failed to free streams {}", this.createdStreams, e);
+        }
+
+        final AmazonKinesisVideo awsSdkKinesisVideoClient = AmazonKinesisVideoClient.builder().build();
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        for (final String streamName : this.createdStreams) {
+            final String finalStreamName = prefix + streamName;
+            try {
+                final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest().withStreamName(finalStreamName);
+                final DescribeStreamResult describeStreamResult = awsSdkKinesisVideoClient.describeStream(describeStreamRequest);
+
+                final DeleteStreamRequest deleteStreamRequest = new DeleteStreamRequest()
+                        .withStreamARN(describeStreamResult.getStreamInfo().getStreamARN())
+                        .withCurrentVersion(describeStreamResult.getStreamInfo().getVersion());
+                awsSdkKinesisVideoClient.deleteStream(deleteStreamRequest);
+            } catch (final Exception e) {
+                failure = true;
+                log.error("Failed to delete the stream: {}", finalStreamName, e);
+            }
+        }
+
+        this.createdStreams.clear();
+
+        assertFalse("An exception happened during cleanup!", failure);
+    }
+
+    /**
+     * Creates test frame data for streaming.
+     *
+     * @return byte array containing test frame data
+     */
+    private byte[] createTestFrameData() {
+        final byte[] frameData = new byte[TEST_FRAME_SIZE_BYTES];
+        for (int i = 0; i < frameData.length; i++) {
+            frameData[i] = (byte) (i % 256);
+        }
+        return frameData;
+    }
+
+    /**
+     * Creates a stream with the given streamName (plus prefix) and tracks.
+     * Also adds the info to the cache.
+     */
+    @SuppressWarnings("ConstantConditions")
+    protected KinesisVideoProducerStream createTestStream(@Nonnull final String streamName,
+                                                          @Nonnull final TrackInfo[] tracks) {
+        assumeTrue("StreamName cannot be null", streamName != null);
+        assumeTrue("Tracks cannot be null", tracks != null);
+        KinesisVideoProducerStream kinesisVideoProducerStream = null;
+
+        final String prefix = Optional.ofNullable(System.getenv("TEST_STREAMS_PREFIX")).orElse("");
+        final String finalStreamName = prefix + streamName;
+        prepareStream(finalStreamName);
+
+        final CachedInfoMultiAuthServiceCallbacksImpl cache = (CachedInfoMultiAuthServiceCallbacksImpl) this.serviceCallbacks;
+
+        try {
+            final AmazonKinesisVideo kinesisVideoClient = AmazonKinesisVideoClientBuilder.defaultClient();
+
+            // Cache DescribeStream
+            final DescribeStreamResult describeStreamResult = kinesisVideoClient.describeStream(new DescribeStreamRequest().withStreamName(finalStreamName));
+            cache.addStreamInfoToCache(finalStreamName, describeStreamResult);
+
+            // Cache GetDataEndpoint
+            final GetDataEndpointResult getDataEndpointResult = kinesisVideoClient.getDataEndpoint(new GetDataEndpointRequest()
+                    .withStreamName(finalStreamName)
+                    .withAPIName(APIName.PUT_MEDIA)
+            );
+            cache.addStreamingEndpointToCache(finalStreamName, getDataEndpointResult.getDataEndpoint());
+
+            // Cache GetStreamingToken
+            cache.addCredentialsProviderToCache(finalStreamName, DefaultAWSCredentialsProviderChain.getInstance());
+        } catch (final Exception e) {
+            log.error("Failed to fetch the stream details: {}", finalStreamName, e);
+            fail();
+        }
+
+        final StreamInfo streamInfo = new StreamInfo(
+                StreamInfo.STREAM_INFO_CURRENT_VERSION,
+                finalStreamName,
+                StreamInfo.StreamingType.STREAMING_TYPE_REALTIME,
+                "audio/PCM",
+                NO_KMS_KEY_ID,
+                RETENTION_ONE_HOUR,
+                NOT_ADAPTIVE,
+                MAX_LATENCY_ZERO,
+                1L * Time.HUNDREDS_OF_NANOS_IN_A_SECOND, // 1 second GOP
+                false, // no keyframe fragmentation
+                USE_FRAME_TIMECODES,
+                RELATIVE_TIMECODES,
+                REQUEST_FRAGMENT_ACKS,
+                RECOVER_ON_FAILURE,
+                DEFAULT_BITRATE,
+                this.fps_,
+                TWENTY_SECONDS_HUNDREDS_OF_NANOS, // 10s buffer
+                DEFAULT_REPLAY_DURATION,
+                DEFAULT_STALENESS_DURATION,
+                DEFAULT_TIMESCALE,
+                RECALCULATE_METRICS,
+                new Tag[]{
+                        new Tag("device", "Test Device"),
+                        new Tag("stream", "Test Stream")},
+                StreamInfo.NalAdaptationFlags.NAL_ADAPTATION_FLAG_NONE,
+                null,
+                tracks,
+                FrameOrderMode.FRAME_ORDERING_MODE_MULTI_TRACK_AV_COMPARE_DTS_ONE_MS_COMPENSATE,
+                StreamInfo.StorePressurePolicy.CONTENT_STORE_PRESSURE_POLICY_DROP_TAIL_ITEM,
+                this.allowStreamCreation
+        );
+
+        try {
+            // Note: Using createStream (not sync version)
+            kinesisVideoProducerStream = this.kinesisVideoProducer.createStream(streamInfo, this.streamCallbacks);
+        } catch (final Exception e) {
+            log.error("Failed to create the stream: {}", finalStreamName, e);
+            fail();
+        }
+
+        return kinesisVideoProducerStream;
+    }
+
+    /**
+     * Tests that the producer correctly handles missing frames from one track and recovers
+     * when the track resumes producing frames.
+     *
+     * <p><strong>Test Flow:</strong></p>
+     * <ol>
+     *   <li>Setup 1 stream with 2 audio tracks and RECOVER_ON_ERROR enabled</li>
+     *   <li>Stream normally for 5 seconds with both tracks</li>
+     *   <li>Stop sending frames for track 2 for 45 seconds, causing FRAMES_MISSING_FOR_TRACK errors</li>
+     *   <li>Resume streaming normally with both tracks for 20 seconds</li>
+     * </ol>
+     *
+     * <p><strong>Expected Behavior:</strong></p>
+     * <ul>
+     *   <li>The stream should receive FRAMES_MISSING_FOR_TRACK error ACKs during the missing frames period</li>
+     *   <li>The stream should recover and receive PERSISTED ACKs after both tracks resume</li>
+     * </ul>
+     */
+    @Test
+    public void test_whenCameraUnreachableScenario_thenWhenCameraIsReachableAgainItRecovers()
+            throws InterruptedException {
+        final String testName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        final String testStreamName = "MissingFramesIntegTest_" + testName + "_" + System.currentTimeMillis();
+
+        final TrackInfo[] tracks = new TrackInfo[]{
+                new TrackInfo(1, "A_MS/ACM", "audio-track-1", null, MkvTrackInfoType.AUDIO),
+                new TrackInfo(2, "A_MS/ACM", "audio-track-2", null, MkvTrackInfoType.AUDIO)
+        };
+
+        // 1 - Create a Kinesis Video Stream with two tracks
+        final KinesisVideoProducerStream stream = createTestStream(testStreamName, tracks);
+        assertNotNull("Stream should be created", stream);
+        this.createdStreams.add(testStreamName);
+
+        // 2 - Start streaming normally for 5s
+        final int framesCorrectly = 50;
+        final int framesAfterFailing = 450;
+        final int framesRecovered = 200;
+        final int fps = 10;
+        long currentFrameTs = System.currentTimeMillis();
+        final byte[] frameData = createTestFrameData();
+
+        for (int frameIndex = 0; frameIndex < framesCorrectly; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    this.frameDuration_,
+                    ByteBuffer.wrap(frameData),
+                    (frameIndex % 2) + 1
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                log.error(e);
+                fail("Unexpected exception during putFrame: " + e);
+            }
+
+            // Make sure no errors via streamErrorReport callback
+            if (this.errorStatus_ != 0) {
+                log.error("Received an unexpected stream error: {}", Long.toHexString(this.errorStatus_));
+                fail("Received an unexpected stream error: " + Long.toHexString(this.errorStatus_));
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // 3 - Interrupt the 2nd track for 40s
+        for (int frameIndex = framesCorrectly; frameIndex < framesAfterFailing + framesCorrectly; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    1000 / fps * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    ByteBuffer.wrap(frameData),
+                    1
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                log.error(e);
+                assertEquals("Expected to receive STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED",
+                        STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED, e.getStatusCode());
+            }
+
+            if (this.errorStatus_ != 0) {
+                assertEquals("Expected to receive stream error: 0x" + Long.toHexString(this.errorStatus_),
+                        STATUS_ACK_ERR_FRAMES_MISSING_FOR_TRACK, this.errorStatus_);
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // Stream normally (recover) for 20s
+        for (int frameIndex = framesAfterFailing + framesCorrectly; frameIndex < framesAfterFailing + framesCorrectly + framesRecovered; frameIndex++) {
+            final long timestampUs = currentFrameTs * 1000;
+
+            final KinesisVideoFrame frame = new KinesisVideoFrame(
+                    frameIndex,
+                    FRAME_FLAG_KEY_FRAME,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    timestampUs * Time.HUNDREDS_OF_NANOS_IN_A_MICROSECOND,
+                    1000 / fps * Time.HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                    ByteBuffer.wrap(frameData),
+                    ((frameIndex + 1) % 2) + 1 // To alternate the track order (to start with the 2nd track to immediately allow frames in again
+            );
+
+            try {
+                stream.putFrame(frame);
+            } catch (final ProducerException e) {
+                log.error(e);
+                fail("Unexpected exception during putFrame: " + e);
+            }
+
+            Thread.sleep(1000 / fps);
+            currentFrameTs += (1000 / fps);
+        }
+
+        // Wait additional time for any delayed error callbacks
+        log.debug("Waiting for all acks to come in...");
+        Thread.sleep(5000);
+
+        // 3 - Verify PERSISTED acks
+        final long persistedAcksCount = this.receivedFragmentAcks_.stream()
+                .filter(ack -> ack.getAckType().getIntType() == FragmentAckType.FRAGMENT_ACK_TYPE_PERSISTED)
+                .count();
+
+        assertTrue("Didn't receive any PERSISTED ACKs. Received: " + this.receivedFragmentAcks_, persistedAcksCount > 0);
+
+        // Wait additional time for any delayed error callbacks
+        log.debug("Waiting for all acks to come in...");
+        Thread.sleep(5000);
+
+        // 4 - Verify the frames missing for track error ack count
+        // The fragmentAckReceived callback implementation (test) stores all the acks received into this receivedFragmentAcks_ array
+        final long numPutMediaFramesMissingForTrackAcks = this.receivedFragmentAcks_.stream()
+                .filter(ack -> ack.getResult() == PUT_MEDIA_ERROR_ACK_FRAMES_MISSING_FOR_TRACK)
+                .count();
+        assertNotEquals("Received no 4011 acks. Expected at least one: " + this.receivedFragmentAcks_,
+                0L, numPutMediaFramesMissingForTrackAcks);
+
+        // 5 - Verify persisted acks from the recovered PutMedia
+        final long finalErrorAckTimestamp = this.receivedFragmentAcks_.stream()
+                .filter(ack -> ack.getAckType().getIntType() == FragmentAckType.FRAGMENT_ACK_TYPE_ERROR)
+                .mapToLong(KinesisVideoFragmentAck::getTimestamp)
+                .max()
+                .orElseThrow(AssertionError::new); // should never happen since there is at least one missing frames err ack in the (4) check
+        final long persistedAcksAfterRecovery = this.receivedFragmentAcks_.stream()
+                .filter(ack -> ack.getTimestamp() > finalErrorAckTimestamp)
+                .filter(ack -> ack.getAckType().getIntType() == FragmentAckType.FRAGMENT_ACK_TYPE_PERSISTED)
+                .count();
+
+        assertTrue("Didn't receive any PERSISTED ACKs after recovery. Received: " + this.receivedFragmentAcks_, persistedAcksAfterRecovery > 0);
+    }
+}

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestBase.java
@@ -1,7 +1,5 @@
 package com.amazonaws.kinesisvideo.common;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -95,7 +93,7 @@ public class ProducerTestBase {
     protected List<KinesisVideoFragmentAck> receivedFragmentAcks_ = new ArrayList<>();
 
     // set by the createProducer method to be used throughout
-    private StreamCallbacks streamCallbacks;
+    protected StreamCallbacks streamCallbacks;
     private KinesisVideoClientConfiguration configuration;
     private AWSCredentialsProvider awsCredentialsProvider;
     private JavaKinesisVideoServiceClient serviceClient;
@@ -103,7 +101,8 @@ public class ProducerTestBase {
     private NativeKinesisVideoClient kinesisVideoClient;
     private AuthCallbacks authCallbacks;
     private StorageCallbacks storageCallbacks;
-    private KinesisVideoProducer kinesisVideoProducer;
+    protected KinesisVideoProducer kinesisVideoProducer;
+    protected ServiceCallbacks serviceCallbacks;
 
     protected void reset() {
         stopCalled_ = false;
@@ -173,6 +172,47 @@ public class ProducerTestBase {
     /**
      * This method is used to create a KinesisVideoProducer which is used by the later methods
      */
+    protected void createCachedProducer(DeviceInfo deviceInfo) {
+
+        reset(); // reset all flags to initial values so that they can be modified by the stream and storage callbacks
+
+        executor = Executors.newScheduledThreadPool(NUMBER_OF_THREADS_IN_POOL,
+                new ThreadFactoryBuilder().setNameFormat("KVS-JavaClientExecutor-%d").build());
+
+        awsCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+        configuration = KinesisVideoClientConfiguration.builder()
+                .withRegion(Regions.US_WEST_2.getName())
+                .withCredentialsProvider(JavaCredentialsFactory.createKinesisVideoCredentialsProvider(awsCredentialsProvider))
+                .build();
+
+        serviceClient = new JavaKinesisVideoServiceClient(log);
+        authCallbacks = new DefaultAuthCallbacks(configuration.getCredentialsProvider(),
+                executor,
+                log);
+        // use TestStorageCallbacks and TestStreamCallbacks to override the callbacks to update the flags in case of
+        // overflow, errors and other events. The current ProducerTestBase object is passed to their constructors so
+        // that they can access the flags to be updated
+        storageCallbacks = new TestStorageCallbacks(this);
+        streamCallbacks = new TestStreamCallBacks(this);
+
+        serviceCallbacks = new CachedInfoMultiAuthServiceCallbacksImpl(log, executor,
+                configuration, serviceClient);
+        kinesisVideoClient = new NativeKinesisVideoClient(log,
+                authCallbacks,
+                storageCallbacks,
+                serviceCallbacks,
+                streamCallbacks);
+        try {
+            kinesisVideoProducer = kinesisVideoClient.initializeNewKinesisVideoProducer(deviceInfo);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    /**
+     * This method is used to create a KinesisVideoProducer which is used by the later methods
+     */
     protected void createProducer(DeviceInfo deviceInfo, ServiceCallbacksConstructor serviceCallbacksConstructor) throws Exception {
 
         reset(); // reset all flags to initial values so that they can be modified by the stream and storage callbacks
@@ -197,12 +237,12 @@ public class ProducerTestBase {
         streamCallbacks = new TestStreamCallBacks(this);
 
         // Use the custom service callbacks (used to inject return values for API calls)
-        ServiceCallbacks defaultServiceCallbacks = serviceCallbacksConstructor.apply(log, executor,
+        serviceCallbacks = serviceCallbacksConstructor.apply(log, executor,
                 configuration, serviceClient);
         kinesisVideoClient = new NativeKinesisVideoClient(log,
                 authCallbacks,
                 storageCallbacks,
-                defaultServiceCallbacks,
+                serviceCallbacks,
                 streamCallbacks);
         try {
             kinesisVideoProducer = kinesisVideoClient.initializeNewKinesisVideoProducer(deviceInfo);
@@ -368,6 +408,15 @@ public class ProducerTestBase {
             kinesisVideoProducer.freeStream(kinesisVideoProducerStream);
         } catch (Exception e) {
             e.printStackTrace();
+            fail();
+        }
+    }
+
+    protected void stopStreams() {
+        try {
+            kinesisVideoProducer.stopStreams();
+        } catch (ProducerException e) {
+            log.error("Failed to stop streams", e);
             fail();
         }
     }

--- a/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestFixture.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/common/ProducerTestFixture.java
@@ -54,7 +54,7 @@ class TestStreamCallBacks extends DefaultStreamCallbacks {
 
         FragmentAckType bufferingAck = new FragmentAckType(FragmentAckType.FRAGMENT_ACK_TYPE_BUFFERING);
 
-        log.trace("Reporting fragment ack {}", fragmentAck);
+        log.info("Received fragment ack {}", fragmentAck);
         if(fragmentAck.getAckType().equals(bufferingAck)) {
             if(producerTestBase.previousBufferingAckTimestamp_.containsKey(uploadHandle)) { //uploadHandle exists in the Map
                 if(fragmentAck.getTimestamp() != producerTestBase.previousBufferingAckTimestamp_.get(uploadHandle) && // can be the same in case of retransmits

--- a/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFragmentAckTest.java
+++ b/src/test/java/com/amazonaws/kinesisvideo/producer/KinesisVideoFragmentAckTest.java
@@ -286,26 +286,26 @@ public class KinesisVideoFragmentAckTest {
         assertTrue(result.contains("\n")); // Should contain newlines for formatting
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void whenCreatingFragmentAckWithEmptySequenceNumberUsingIntConstructor_thenShouldThrowException() {
+    @Test
+    public void whenCreatingFragmentAckWithEmptySequenceNumberUsingIntConstructor_thenShouldNotThrowException() {
         // Given
         int ackType = FragmentAckType.FRAGMENT_ACK_TYPE_BUFFERING;
         
         // When
         new KinesisVideoFragmentAck(ackType, TEST_TIMESTAMP, "", HTTP_OK);
         
-        // Then - exception should be thrown
+        // Then - no exception should be thrown
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void whenCreatingFragmentAckWithEmptySequenceNumberUsingObjectConstructor_thenShouldThrowException() {
+    @Test
+    public void whenCreatingFragmentAckWithEmptySequenceNumberUsingObjectConstructor_thenShouldNotThrowException() {
         // Given
         FragmentAckType ackType = new FragmentAckType(FragmentAckType.FRAGMENT_ACK_TYPE_RECEIVED);
         
         // When
         new KinesisVideoFragmentAck(ackType, TEST_TIMESTAMP, "", HTTP_OK);
         
-        // Then - exception should be thrown
+        // Then - no exception should be thrown
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Rebase #265 to the latest develop branch (with the async fix)
- Adding the stream restart tests due to invalid media (putmedia connection restart)
- As seen in #265 (made before the fix in #270), the test ran into the deadlock
- See #265 for the original details

*Why was it changed?*
- See #265 for the original details

*How was it changed?*
- See #265 for the original details

*What testing was done for the changes?*
- The CI should pass for this one, whereas it previously failed in #265

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
