### PR TITLE
Add permissions for pull-requests in workflow

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -10,12 +10,11 @@ on:
       - master
       - develop
 
-permissions:
-  contents: write
-
 jobs:
   javadoc:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/pr-desc-check.yml
+++ b/.github/workflows/pr-desc-check.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   check-description:
     runs-on: macos-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Install GitHub CLI
         run: |


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add explicit permission to pr-desc-check workflow

*Why was it changed?*
- Use minimal permissions

*How was it changed?*
- Add PR-read (for `github.token` oauth)
- Didn't add id-token (workflow identity) which is used for oidc

*What testing was done for the changes?*
- Tested on a fork, actions was still able to fetch the PR description to validate it
- We'll know if it validated this PR's description

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.